### PR TITLE
small fix: book.tsx stars and ratings on hover are displayed correctly

### DIFF
--- a/src/pages/components/book.tsx
+++ b/src/pages/components/book.tsx
@@ -152,7 +152,7 @@ export const BookListItem: FC<{
     "stars" in book && book.stars !== null
       ? book.stars / 2
       : "rating" in book
-        ? book.rating || 0
+        ? (book.rating || 0) / 1000
         : 0;
   return (
     <li className="group relative flex justify-center">
@@ -198,7 +198,7 @@ export const BookListItem: FC<{
                       style={{
                         clipPath: `inset(0 ${
                           100 -
-                          Math.min(100, Math.max(0, rating - (star - 1) * 100))
+                          Math.min(100, Math.max(0, (rating - (star - 1)) * 100))
                         }% 0 0)`,
                       }}
                       class="fill-current text-yellow-400"


### PR DESCRIPTION
Hi Nick, this is just a fix for a very small issue that has been bugging me: when you hover over a book currently, the way the stars and ratings are displayed is a bit off like how user reviews always seem to show 0 stars and average reviews always 5 stars regardless of actual rating.
I suppose the rating averages from Goodreads just come in four digit numbers? Dividing by one thousand might be a band-aid solution, but it works. As for the stars, I think there was just a small math operation oversight.

Pls be nice, this is literally my first pull request ever.

**Before**:
<img width="429" height="435" alt="Screenshot_20251113_022148" src="https://github.com/user-attachments/assets/aa3883f8-14e6-47c4-a854-8ec808bfd8ad" />
<img width="429" height="435" alt="Screenshot_20251113_022153" src="https://github.com/user-attachments/assets/40dbd580-2789-434b-a944-21ebedcfa639" />
**After**:
<img width="429" height="435" alt="Screenshot_20251113_022201" src="https://github.com/user-attachments/assets/489f0213-9a9e-4ce0-8a3b-ef856c9e1acc" />
<img width="429" height="435" alt="Screenshot_20251113_022204" src="https://github.com/user-attachments/assets/aa7fc66e-891c-4187-8935-3b5b982bdb35" />
