### PR TITLE
Book ID map lexicon

### DIFF
--- a/lexicons/defs.json
+++ b/lexicons/defs.json
@@ -282,6 +282,28 @@
           "description": "When the progress was last updated"
         }
       }
+    },
+    "bookIdMap": {
+      "type": "object",
+      "required": ["hiveId"],
+      "properties": {
+        "hiveId": {
+          "type": "string",
+          "description": "The hive ID for the book"
+        },
+        "isbn": {
+          "type": "string",
+          "description": "The book ISBN identifier"
+        },
+        "isbn13": {
+          "type": "string",
+          "description": "The book ISBN-13 identifier"
+        },
+        "goodreadsId": {
+          "type": "string",
+          "description": "The Goodreads identifier for the book"
+        }
+      }
     }
   }
 }

--- a/lexicons/getBookIdMap.json
+++ b/lexicons/getBookIdMap.json
@@ -1,0 +1,44 @@
+{
+  "lexicon": 1,
+  "id": "buzz.bookhive.getBookIdMap",
+  "defs": {
+    "main": {
+      "type": "query",
+      "description": "Resolve a book identifier map by hiveId, isbn, isbn13, or goodreadsId. Does not require authentication.",
+      "parameters": {
+        "type": "params",
+        "properties": {
+          "hiveId": {
+            "type": "string",
+            "description": "The book hive ID"
+          },
+          "isbn": {
+            "type": "string",
+            "description": "The book ISBN identifier"
+          },
+          "isbn13": {
+            "type": "string",
+            "description": "The book ISBN-13 identifier"
+          },
+          "goodreadsId": {
+            "type": "string",
+            "description": "The Goodreads identifier for the book"
+          }
+        }
+      },
+      "output": {
+        "encoding": "application/json",
+        "schema": {
+          "type": "object",
+          "required": ["bookIdMap"],
+          "properties": {
+            "bookIdMap": {
+              "type": "ref",
+              "ref": "buzz.bookhive.defs#bookIdMap"
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/src/bsky/lexicon/index.ts
+++ b/src/bsky/lexicon/index.ts
@@ -10,6 +10,7 @@ import {
 } from "@atproto/xrpc-server";
 import { schemas } from "./lexicons.js";
 import * as BuzzBookhiveGetBook from "./types/buzz/bookhive/getBook.js";
+import * as BuzzBookhiveGetBookIdMap from "./types/buzz/bookhive/getBookIdMap.js";
 import * as BuzzBookhiveGetProfile from "./types/buzz/bookhive/getProfile.js";
 import * as BuzzBookhiveSearchBooks from "./types/buzz/bookhive/searchBooks.js";
 
@@ -62,6 +63,17 @@ export class BuzzBookhiveNS {
     >,
   ) {
     const nsid = "buzz.bookhive.getBook"; // @ts-ignore
+    return this._server.xrpc.method(nsid, cfg);
+  }
+
+  getBookIdMap<AV extends AuthVerifier>(
+    cfg: ConfigOf<
+      AV,
+      BuzzBookhiveGetBookIdMap.Handler<ExtractAuth<AV>>,
+      BuzzBookhiveGetBookIdMap.HandlerReqCtx<ExtractAuth<AV>>
+    >,
+  ) {
+    const nsid = "buzz.bookhive.getBookIdMap"; // @ts-ignore
     return this._server.xrpc.method(nsid, cfg);
   }
 

--- a/src/bsky/lexicon/lexicons.ts
+++ b/src/bsky/lexicon/lexicons.ts
@@ -416,6 +416,28 @@ export const schemaDict = {
           },
         },
       },
+      bookIdMap: {
+        type: "object",
+        required: ["hiveId"],
+        properties: {
+          hiveId: {
+            type: "string",
+            description: "The hive ID for the book",
+          },
+          isbn: {
+            type: "string",
+            description: "The book ISBN identifier",
+          },
+          isbn13: {
+            type: "string",
+            description: "The book ISBN-13 identifier",
+          },
+          goodreadsId: {
+            type: "string",
+            description: "The Goodreads identifier for the book",
+          },
+        },
+      },
     },
   },
   BuzzBookhiveGetBook: {
@@ -516,6 +538,51 @@ export const schemaDict = {
                   type: "ref",
                   ref: "lex:buzz.bookhive.defs#activity",
                 },
+              },
+            },
+          },
+        },
+      },
+    },
+  },
+  BuzzBookhiveGetBookIdMap: {
+    lexicon: 1,
+    id: "buzz.bookhive.getBookIdMap",
+    defs: {
+      main: {
+        type: "query",
+        description:
+          "Resolve a book identifier map by hiveId, isbn, isbn13, or goodreadsId. Does not require authentication.",
+        parameters: {
+          type: "params",
+          properties: {
+            hiveId: {
+              type: "string",
+              description: "The book hive ID",
+            },
+            isbn: {
+              type: "string",
+              description: "The book ISBN identifier",
+            },
+            isbn13: {
+              type: "string",
+              description: "The book ISBN-13 identifier",
+            },
+            goodreadsId: {
+              type: "string",
+              description: "The Goodreads identifier for the book",
+            },
+          },
+        },
+        output: {
+          encoding: "application/json",
+          schema: {
+            type: "object",
+            required: ["bookIdMap"],
+            properties: {
+              bookIdMap: {
+                type: "ref",
+                ref: "lex:buzz.bookhive.defs#bookIdMap",
               },
             },
           },
@@ -783,6 +850,7 @@ export const ids = {
   BuzzBookhiveBuzz: "buzz.bookhive.buzz",
   BuzzBookhiveDefs: "buzz.bookhive.defs",
   BuzzBookhiveGetBook: "buzz.bookhive.getBook",
+  BuzzBookhiveGetBookIdMap: "buzz.bookhive.getBookIdMap",
   BuzzBookhiveGetProfile: "buzz.bookhive.getProfile",
   BuzzBookhiveHiveBook: "buzz.bookhive.hiveBook",
   BuzzBookhiveSearchBooks: "buzz.bookhive.searchBooks",

--- a/src/bsky/lexicon/types/buzz/bookhive/defs.ts
+++ b/src/bsky/lexicon/types/buzz/bookhive/defs.ts
@@ -194,3 +194,25 @@ export function isBookProgress<V>(v: V) {
 export function validateBookProgress<V>(v: V) {
   return validate<BookProgress & V>(v, id, hashBookProgress);
 }
+
+export interface BookIdMap {
+  $type?: "buzz.bookhive.defs#bookIdMap";
+  /** The hive ID for the book */
+  hiveId: string;
+  /** The book ISBN identifier */
+  isbn?: string;
+  /** The book ISBN-13 identifier */
+  isbn13?: string;
+  /** The Goodreads identifier for the book */
+  goodreadsId?: string;
+}
+
+const hashBookIdMap = "bookIdMap";
+
+export function isBookIdMap<V>(v: V) {
+  return is$typed(v, id, hashBookIdMap);
+}
+
+export function validateBookIdMap<V>(v: V) {
+  return validate<BookIdMap & V>(v, id, hashBookIdMap);
+}

--- a/src/bsky/lexicon/types/buzz/bookhive/getBookIdMap.ts
+++ b/src/bsky/lexicon/types/buzz/bookhive/getBookIdMap.ts
@@ -1,0 +1,61 @@
+/**
+ * GENERATED CODE - DO NOT MODIFY
+ */
+import express from "express";
+import { type ValidationResult, BlobRef } from "@atproto/lexicon";
+import { CID } from "multiformats/cid";
+import { validate as _validate } from "../../../lexicons";
+import {
+  type $Typed,
+  is$typed as _is$typed,
+  type OmitKey,
+} from "../../../util";
+import { HandlerAuth, HandlerPipeThrough } from "@atproto/xrpc-server";
+import type * as BuzzBookhiveDefs from "./defs.js";
+
+const is$typed = _is$typed,
+  validate = _validate;
+const id = "buzz.bookhive.getBookIdMap";
+
+export interface QueryParams {
+  /** The book hive ID */
+  hiveId?: string;
+  /** The book ISBN identifier */
+  isbn?: string;
+  /** The book ISBN-13 identifier */
+  isbn13?: string;
+  /** The Goodreads identifier for the book */
+  goodreadsId?: string;
+}
+
+export type InputSchema = undefined;
+
+export interface OutputSchema {
+  bookIdMap: BuzzBookhiveDefs.BookIdMap;
+}
+
+export type HandlerInput = undefined;
+
+export interface HandlerSuccess {
+  encoding: "application/json";
+  body: OutputSchema;
+  headers?: { [key: string]: string };
+}
+
+export interface HandlerError {
+  status: number;
+  message?: string;
+}
+
+export type HandlerOutput = HandlerError | HandlerSuccess | HandlerPipeThrough;
+export type HandlerReqCtx<HA extends HandlerAuth = never> = {
+  auth: HA;
+  params: QueryParams;
+  input: HandlerInput;
+  req: express.Request;
+  res: express.Response;
+  resetRouteRateLimits: () => Promise<void>;
+};
+export type Handler<HA extends HandlerAuth = never> = (
+  ctx: HandlerReqCtx<HA>,
+) => Promise<HandlerOutput> | HandlerOutput;

--- a/src/db.ts
+++ b/src/db.ts
@@ -3,14 +3,22 @@ import {
   Kysely,
   Migrator,
   SqliteDialect,
+  sql,
   type Migration,
   type MigrationProvider,
 } from "kysely";
-import type { Buzz, HiveBook, UserBookRow, UserFollow } from "./types";
+import type {
+  BookIdMap,
+  Buzz,
+  HiveBook,
+  UserBookRow,
+  UserFollow,
+} from "./types";
 
 // Types
 export type DatabaseSchema = {
   hive_book: HiveBook;
+  book_id_map: BookIdMap;
   user_book: UserBookRow;
   buzz: Buzz;
   user_follows: UserFollow;
@@ -200,6 +208,60 @@ migrations["006"] = {
       .alterTable("user_book")
       .dropColumn("bookProgress")
       .execute();
+  },
+};
+
+migrations["007"] = {
+  async up(db: Kysely<unknown>) {
+    await db.schema
+      .createTable("book_id_map")
+      .addColumn("hiveId", "text", (col) => col.primaryKey())
+      .addColumn("isbn", "text")
+      .addColumn("isbn13", "text")
+      .addColumn("goodreadsId", "text")
+      .addColumn("updatedAt", "text", (col) => col.notNull())
+      .execute();
+
+    await db.schema
+      .createIndex("idx_book_id_map_isbn")
+      .on("book_id_map")
+      .column("isbn")
+      .execute();
+
+    await db.schema
+      .createIndex("idx_book_id_map_isbn13")
+      .on("book_id_map")
+      .column("isbn13")
+      .execute();
+
+    await db.schema
+      .createIndex("idx_book_id_map_goodreads_id")
+      .on("book_id_map")
+      .column("goodreadsId")
+      .execute();
+
+    await sql`
+      INSERT INTO book_id_map (hiveId, isbn, isbn13, goodreadsId, updatedAt)
+      SELECT
+        id,
+        NULLIF(REPLACE(REPLACE(UPPER(CAST(json_extract(meta, '$.isbn') AS TEXT)), '-', ''), ' ', ''), ''),
+        NULLIF(REPLACE(REPLACE(CAST(json_extract(meta, '$.isbn13') AS TEXT), '-', ''), ' ', ''), ''),
+        CASE
+          WHEN source = 'Goodreads' THEN NULLIF(
+            CASE
+              WHEN instr(COALESCE(sourceId, ''), '.') > 0 THEN substr(sourceId, 1, instr(sourceId, '.') - 1)
+              ELSE sourceId
+            END,
+            ''
+          )
+          ELSE NULL
+        END,
+        updatedAt
+      FROM hive_book
+    `.execute(db);
+  },
+  async down(db: Kysely<unknown>) {
+    await db.schema.dropTable("book_id_map").execute();
   },
 };
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,5 @@
 export type * as GetBook from "./bsky/lexicon/types/buzz/bookhive/getBook";
+export type * as GetBookIdMap from "./bsky/lexicon/types/buzz/bookhive/getBookIdMap";
 export type * as GetProfile from "./bsky/lexicon/types/buzz/bookhive/getProfile";
 
 /**
@@ -148,6 +149,14 @@ export type HiveBook = {
   series: string | null;
   meta: string | null;
   enrichedAt: string | null;
+};
+
+export type BookIdMap = {
+  hiveId: HiveId;
+  isbn: string | null;
+  isbn13: string | null;
+  goodreadsId: string | null;
+  updatedAt: string;
 };
 
 export type UserFollow = {

--- a/src/utils/bookIdMap.ts
+++ b/src/utils/bookIdMap.ts
@@ -1,0 +1,173 @@
+import type { Database } from "../db";
+import type { BookIdMap, HiveBook, HiveId } from "../types";
+
+type BookIdMapSource = Pick<
+  HiveBook,
+  "id" | "source" | "sourceId" | "sourceUrl" | "meta"
+>;
+
+type ParsedMeta = {
+  isbn?: unknown;
+  isbn13?: unknown;
+};
+
+const GOODREADS_BOOK_PATH_REGEX = /\/book\/show\/([^/?#]+)/i;
+
+function normalizeString(value: string | null | undefined): string | null {
+  const normalized = value?.trim();
+  return normalized ? normalized : null;
+}
+
+export function normalizeHiveId(
+  value: string | null | undefined,
+): HiveId | null {
+  const normalized = normalizeString(value);
+  return normalized ? (normalized as HiveId) : null;
+}
+
+export function normalizeIsbn(value: string | null | undefined): string | null {
+  const normalized = normalizeString(value);
+  if (!normalized) {
+    return null;
+  }
+
+  const compact = normalized.replace(/[\s-]+/g, "").toUpperCase();
+  return compact || null;
+}
+
+export function normalizeIsbn13(
+  value: string | null | undefined,
+): string | null {
+  const normalized = normalizeString(value);
+  if (!normalized) {
+    return null;
+  }
+
+  const compact = normalized.replace(/[\s-]+/g, "");
+  return compact || null;
+}
+
+export function normalizeGoodreadsId(
+  value: string | null | undefined,
+): string | null {
+  const normalized = normalizeString(value);
+  if (!normalized) {
+    return null;
+  }
+
+  // Goodreads ids can appear as "12345.title-slug"
+  const [id] = normalized.split(".", 1);
+  return id || null;
+}
+
+function parseMeta(meta: string | null): ParsedMeta {
+  if (!meta) {
+    return {};
+  }
+
+  try {
+    const parsed = JSON.parse(meta) as ParsedMeta;
+    return parsed && typeof parsed === "object" ? parsed : {};
+  } catch {
+    return {};
+  }
+}
+
+function extractGoodreadsId(book: BookIdMapSource): string | null {
+  if (book.source === "Goodreads") {
+    const fromSourceId = normalizeGoodreadsId(book.sourceId);
+    if (fromSourceId) {
+      return fromSourceId;
+    }
+  }
+
+  const sourceUrl = normalizeString(book.sourceUrl);
+  if (!sourceUrl) {
+    return null;
+  }
+
+  const match = sourceUrl.match(GOODREADS_BOOK_PATH_REGEX);
+  if (!match?.[1]) {
+    return null;
+  }
+
+  return normalizeGoodreadsId(match[1]);
+}
+
+export function deriveBookIdMap(
+  book: BookIdMapSource,
+): Omit<BookIdMap, "updatedAt"> {
+  const meta = parseMeta(book.meta);
+  return {
+    hiveId: book.id,
+    isbn: normalizeIsbn(typeof meta.isbn === "string" ? meta.isbn : null),
+    isbn13: normalizeIsbn13(
+      typeof meta.isbn13 === "string" ? meta.isbn13 : null,
+    ),
+    goodreadsId: extractGoodreadsId(book),
+  };
+}
+
+export function toBookIdMapOutput(bookIdMap: Omit<BookIdMap, "updatedAt">) {
+  return {
+    hiveId: bookIdMap.hiveId,
+    isbn: bookIdMap.isbn ?? undefined,
+    isbn13: bookIdMap.isbn13 ?? undefined,
+    goodreadsId: bookIdMap.goodreadsId ?? undefined,
+  };
+}
+
+export async function upsertBookIdMap(db: Database, book: BookIdMapSource) {
+  const map = deriveBookIdMap(book);
+  const updatedAt = new Date().toISOString();
+
+  await db
+    .insertInto("book_id_map")
+    .values({
+      hiveId: map.hiveId,
+      isbn: map.isbn,
+      isbn13: map.isbn13,
+      goodreadsId: map.goodreadsId,
+      updatedAt,
+    })
+    .onConflict((oc) =>
+      oc.column("hiveId").doUpdateSet((eb) => ({
+        isbn: eb.ref("excluded.isbn"),
+        isbn13: eb.ref("excluded.isbn13"),
+        goodreadsId: eb.ref("excluded.goodreadsId"),
+        updatedAt: eb.ref("excluded.updatedAt"),
+      })),
+    )
+    .execute();
+}
+
+export async function upsertBookIdMaps(db: Database, books: BookIdMapSource[]) {
+  if (!books.length) {
+    return;
+  }
+
+  const updatedAt = new Date().toISOString();
+  const values = books.map((book) => {
+    const map = deriveBookIdMap(book);
+    return {
+      hiveId: map.hiveId,
+      isbn: map.isbn,
+      isbn13: map.isbn13,
+      goodreadsId: map.goodreadsId,
+      updatedAt,
+    };
+  });
+
+  await db
+    .insertInto("book_id_map")
+    .values(values)
+    .onConflict((oc) =>
+      oc.column("hiveId").doUpdateSet((eb) => ({
+        isbn: eb.ref("excluded.isbn"),
+        isbn13: eb.ref("excluded.isbn13"),
+        goodreadsId: eb.ref("excluded.goodreadsId"),
+        updatedAt: eb.ref("excluded.updatedAt"),
+      })),
+    )
+    .execute();
+}


### PR DESCRIPTION
Adds an unauthenticated XRPC endpoint and indexed database table to map book identifiers (hiveId, ISBN, ISBN13, Goodreads ID) for efficient cross-reference and on-demand enrichment.

---
<p><a href="https://cursor.com/background-agent?bcId=bc-ec0e69b7-88ef-440f-97f0-568dae39b648"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-ec0e69b7-88ef-440f-97f0-568dae39b648"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

