### PR TITLE
fix: consolidate worker build output to .output/server/workers/

### DIFF
--- a/src/context.ts
+++ b/src/context.ts
@@ -164,7 +164,7 @@ export async function createAppDeps(): Promise<AppDeps> {
   // In dev, Bun runs the .ts source directly.
   const isBundled = import.meta.url.includes(".output/");
   const workerUrl = isBundled
-    ? new URL("./ingester-worker.js", import.meta.url).href
+    ? new URL("./workers/ingester-worker.js", import.meta.url).href
     : new URL("./workers/ingester-worker.ts", import.meta.url).href;
   const ingesterWorker = new Worker(workerUrl);
   ingesterWorker.onmessage = (event: MessageEvent) => {

--- a/src/logger/index.ts
+++ b/src/logger/index.ts
@@ -14,7 +14,7 @@ function createOpenObserveStream(): Writable | null {
   }
 
   const workerUrl = isBundled
-    ? new URL("./logger/open-observe-worker.js", import.meta.url).href
+    ? new URL("./workers/open-observe-worker.js", import.meta.url).href
     : new URL("../workers/open-observe-worker.ts", import.meta.url).href;
 
   loggerWorker = new Worker(workerUrl);

--- a/src/routes/import.ts
+++ b/src/routes/import.ts
@@ -48,7 +48,11 @@ async function handleImport(c: Context<AppEnv>, exportFile: File, type: ImportRe
     const ac = new AbortController();
     const timeout = setTimeout(() => ac.abort(), IMPORT_TIMEOUT_MS);
 
-    const worker = new Worker(new URL("../workers/import/index.ts", import.meta.url));
+    const isBundled = import.meta.url.includes(".output/");
+    const workerUrl = isBundled
+      ? new URL("./workers/import-worker.js", import.meta.url).href
+      : new URL("../workers/import/index.ts", import.meta.url).href;
+    const worker = new Worker(workerUrl);
 
     const cleanup = () => {
       clearTimeout(timeout);

--- a/src/workers/og-render/client.ts
+++ b/src/workers/og-render/client.ts
@@ -13,7 +13,7 @@ function getWorker(): Worker {
 
   const isBundled = import.meta.url.includes(".output/");
   const workerUrl = isBundled
-    ? new URL("./workers/og-render/og-render-worker.js", import.meta.url).href
+    ? new URL("./workers/og-render-worker.js", import.meta.url).href
     : new URL("./og-render-worker.tsx", import.meta.url).href;
 
   worker = new Worker(workerUrl);

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -11,21 +11,27 @@ function standaloneBundles(): Plugin {
   const bundles = [
     {
       entrypoint: "./src/workers/ingester-worker.ts",
-      outdir: "./.output/server",
+      outdir: "./.output/server/workers",
       name: "ingester-worker.js",
       label: "Ingester worker",
     },
     {
       entrypoint: "./src/workers/open-observe-worker.ts",
-      outdir: "./.output/server/logger",
+      outdir: "./.output/server/workers",
       name: "open-observe-worker.js",
       label: "OpenObserve logger worker",
     },
     {
       entrypoint: "./src/workers/og-render/og-render-worker.tsx",
-      outdir: "./.output/server/workers/og-render",
+      outdir: "./.output/server/workers",
       name: "og-render-worker.js",
       label: "OG render worker",
+    },
+    {
+      entrypoint: "./src/workers/import/index.ts",
+      outdir: "./.output/server/workers",
+      name: "import-worker.js",
+      label: "Import worker",
     },
   ];
 


### PR DESCRIPTION
## Summary
- All 4 workers (ingester, open-observe logger, OG render, import) now build to `.output/server/workers/` instead of being scattered across `.output/server/`, `.output/server/logger/`, and `.output/server/workers/og-render/`.
- The import worker was not being built at all — it's now included in the Vite `standaloneBundles` plugin.
- Fixed production `new URL()` paths in all consumer files (`context.ts`, `logger/index.ts`, `og-render/client.ts`, `routes/import.ts`) to resolve correctly from the Nitro bundle.

## Test plan
- [x] `bun run build` succeeds and all 4 workers appear in `.output/server/workers/`
- [x] Verified compiled `index.mjs` contains correct `./workers/*.js` paths for prod branches
- [ ] Smoke test import, OG image, ingester, and logging in a deployed environment

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Standardized worker module bundling and path resolution for improved consistency in packaged builds. Worker files are now consolidated to a unified output directory with corrected path references during bundled deployment, ensuring stable worker initialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->