### PR TITLE
fix: redirect to /home after OAuth to avoid cached marketing page

### DIFF
--- a/src/auth/router.tsx
+++ b/src/auth/router.tsx
@@ -6,6 +6,7 @@ import type { Did } from "@atcute/lexicons";
 import type { ActorIdentifier } from "@atcute/lexicons/syntax";
 import { env } from "../env";
 import type { AppContext, HonoServer, Session } from "../context";
+import { setCachedSessionClient } from "../context";
 import { Layout } from "../pages/layout";
 
 import { Error } from "../pages/error";
@@ -81,6 +82,12 @@ export function loginRouter(
       await clientSession.save();
 
       const agent = sessionClientFromOAuthSession(session);
+
+      // Pre-warm the in-memory session cache so the first request after login
+      // doesn't need to call oauthClient.restore() (which can race with onLogin background tasks).
+      const tokenInfo = await session.getTokenInfo(false);
+      setCachedSessionClient(session.did, agent, tokenInfo.expiresAt?.getTime());
+
       await onLogin({ agent, ctx: c.get("ctx") });
 
       if (state && typeof state === "object" && "redirectUri" in state) {
@@ -115,7 +122,11 @@ export function loginRouter(
         }
       }
 
-      return c.redirect("/");
+      // Redirect to /home instead of / — the marketing page at / is cached by the browser
+      // (Cache-Control: public, max-age=3600), so a redirect there after login would serve
+      // the stale signed-out page. /home is never cached and handles unauthenticated users
+      // by redirecting to / itself.
+      return c.redirect("/home");
     } catch (err: unknown) {
       const errMsg =
         typeof err === "object" && err !== null && "message" in err

--- a/src/context.ts
+++ b/src/context.ts
@@ -231,7 +231,7 @@ function getCachedSessionClient(did: string): { client: SessionClient; needsSave
   };
 }
 
-function setCachedSessionClient(
+export function setCachedSessionClient(
   did: string,
   client: SessionClient,
   tokenExpiresAt: number | undefined,


### PR DESCRIPTION
## Summary
- After OAuth login, the browser served the stale cached marketing page (`/` has `Cache-Control: public, max-age=3600`) instead of making a fresh request to the server
- Fix: redirect the OAuth callback to `/home` instead of `/`, which is never browser-cached
- Pre-warm the in-memory session client cache during the OAuth callback so the first post-login request doesn't need `oauthClient.restore()`

## Test plan
- [x] Sign in via OAuth and verify you land on the authenticated home page immediately
- [ ] Verify refresh still works correctly after login
- [ ] Verify mobile OAuth redirect flow still works (state with redirectUri)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  - Post-login redirection has been updated to route users directly to the dashboard interface rather than the application root, streamlining the user's entry point to primary features
  - Authentication session management and initialization procedures during the OAuth flow have been enhanced and optimized, delivering improved stability, reliability, and overall performance during the login process

<!-- end of auto-generated comment: release notes by coderabbit.ai -->