### PR TITLE
chore: bump Bun from 1.3.9 to 1.3.12

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1
-FROM oven/bun:1.3.9-alpine AS base
+FROM oven/bun:1.3.12-alpine AS base
 WORKDIR /usr/src/app
 RUN rm -rf /var/cache/apk/*
 

--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
     "zod": "^3.25.76"
   },
   "engines": {
-    "bun": ">=1.3.9"
+    "bun": ">=1.3.12"
   },
   "patchedDependencies": {
     "ipx@4.0.0-alpha.1": "patches/ipx@4.0.0-alpha.1.patch",


### PR DESCRIPTION
## Summary
- Updates Bun version from 1.3.9 to 1.3.12 in Dockerfile and package.json engines field

## Test plan
- [ ] Verify Docker build succeeds with new base image
- [ ] Verify app starts correctly with Bun 1.3.12

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated minimum Bun runtime version requirement to 1.3.12.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->