### PR TITLE
feat: add genre filter to shelf pages in iOS app

### DIFF
--- a/app/app/(tabs)/books/[status].tsx
+++ b/app/app/(tabs)/books/[status].tsx
@@ -150,21 +150,18 @@ function FilteredBooksContent({ status }: { status: string }) {
       .map(([genre, count]) => ({ genre, count }));
   }, [statusBooks]);
 
-  useEffect(() => {
-    if (selectedGenre && !availableGenres.some((g) => g.genre === selectedGenre)) {
-      setSelectedGenre(null);
-    }
-  }, [availableGenres, selectedGenre]);
+  const activeGenre =
+    selectedGenre && availableGenres.some((g) => g.genre === selectedGenre) ? selectedGenre : null;
 
   const filteredBooks = useMemo(() => {
-    const genreFiltered = selectedGenre
+    const genreFiltered = activeGenre
       ? statusBooks.filter((book) => {
           const genres = (book as any).genres as string[] | undefined;
-          return genres?.includes(selectedGenre);
+          return genres?.includes(activeGenre);
         })
       : statusBooks;
     return sortBooks(genreFiltered, sortBy, sortOrder, config.status);
-  }, [statusBooks, selectedGenre, sortBy, sortOrder, config.status]);
+  }, [statusBooks, activeGenre, sortBy, sortOrder, config.status]);
 
   // Calculate responsive number of columns
   useEffect(() => {
@@ -349,20 +346,20 @@ function FilteredBooksContent({ status }: { status: string }) {
               style={[
                 styles.sortButton,
                 {
-                  backgroundColor: !selectedGenre ? colors.primary : colors.buttonBackground,
-                  borderColor: !selectedGenre ? colors.primary : colors.buttonBorder,
+                  backgroundColor: !activeGenre ? colors.primary : colors.buttonBackground,
+                  borderColor: !activeGenre ? colors.primary : colors.buttonBorder,
                 },
               ]}
             >
               <Ionicons
                 name="pricetags-outline"
                 size={16}
-                color={!selectedGenre ? colors.background : colors.primary}
+                color={!activeGenre ? colors.background : colors.primary}
               />
               <ThemedText
                 style={[
                   styles.sortButtonText,
-                  { color: !selectedGenre ? colors.background : colors.primaryText },
+                  { color: !activeGenre ? colors.background : colors.primaryText },
                 ]}
                 type="label"
               >
@@ -370,7 +367,7 @@ function FilteredBooksContent({ status }: { status: string }) {
               </ThemedText>
             </Pressable>
             {availableGenres.map(({ genre, count }) => {
-              const isActive = selectedGenre === genre;
+              const isActive = activeGenre === genre;
               return (
                 <Pressable
                   key={genre}
@@ -431,7 +428,7 @@ function FilteredBooksContent({ status }: { status: string }) {
               No matches
             </ThemedText>
             <ThemedText style={[styles.emptySubtitle, { color: colors.secondaryText }]} type="body">
-              No books in {selectedGenre ? `"${selectedGenre}"` : "this filter"}. Try another genre.
+              No books in {activeGenre ? `"${activeGenre}"` : "this filter"}. Try another genre.
             </ThemedText>
           </ThemedView>
         </View>

--- a/app/app/(tabs)/books/[status].tsx
+++ b/app/app/(tabs)/books/[status].tsx
@@ -123,19 +123,48 @@ function FilteredBooksContent({ status }: { status: string }) {
   const [numColumns, setNumColumns] = useState(2);
   const [sortBy, setSortBy] = useState<SortBy>("dateAdded");
   const [sortOrder, setSortOrder] = useState<SortOrder>("desc");
+  const [selectedGenre, setSelectedGenre] = useState<string | null>(null);
 
   const profile = useProfile();
 
   const config = STATUS_CONFIG[status as keyof typeof STATUS_CONFIG];
 
-  const filteredBooks = useMemo(() => {
+  const statusBooks = useMemo(() => {
     if (!profile.data) return [];
-    const filtered =
-      config.status === "owned"
-        ? profile.data.books.filter((book: any) => book.owned)
-        : profile.data.books.filter((book) => book.status === config.status);
-    return sortBooks(filtered, sortBy, sortOrder, config.status);
-  }, [profile.data, config.status, sortBy, sortOrder]);
+    return config.status === "owned"
+      ? profile.data.books.filter((book: any) => book.owned)
+      : profile.data.books.filter((book) => book.status === config.status);
+  }, [profile.data, config.status]);
+
+  const availableGenres = useMemo(() => {
+    const counts = new Map<string, number>();
+    for (const book of statusBooks) {
+      const genres = (book as any).genres as string[] | undefined;
+      if (!genres) continue;
+      for (const genre of genres) {
+        counts.set(genre, (counts.get(genre) ?? 0) + 1);
+      }
+    }
+    return Array.from(counts.entries())
+      .sort((a, b) => b[1] - a[1] || a[0].localeCompare(b[0]))
+      .map(([genre, count]) => ({ genre, count }));
+  }, [statusBooks]);
+
+  useEffect(() => {
+    if (selectedGenre && !availableGenres.some((g) => g.genre === selectedGenre)) {
+      setSelectedGenre(null);
+    }
+  }, [availableGenres, selectedGenre]);
+
+  const filteredBooks = useMemo(() => {
+    const genreFiltered = selectedGenre
+      ? statusBooks.filter((book) => {
+          const genres = (book as any).genres as string[] | undefined;
+          return genres?.includes(selectedGenre);
+        })
+      : statusBooks;
+    return sortBooks(genreFiltered, sortBy, sortOrder, config.status);
+  }, [statusBooks, selectedGenre, sortBy, sortOrder, config.status]);
 
   // Calculate responsive number of columns
   useEffect(() => {
@@ -196,7 +225,7 @@ function FilteredBooksContent({ status }: { status: string }) {
     );
   }
 
-  if (filteredBooks.length === 0) {
+  if (statusBooks.length === 0) {
     return (
       <View style={[styles.container, { backgroundColor, paddingBottom: bottom }]}>
         <BackNavigationHeader title={config.title} />
@@ -308,11 +337,105 @@ function FilteredBooksContent({ status }: { status: string }) {
         </ScrollView>
       </View>
 
+      {availableGenres.length > 0 && (
+        <View style={styles.genreContainer}>
+          <ScrollView
+            horizontal
+            showsHorizontalScrollIndicator={false}
+            contentContainerStyle={styles.sortButtonsContainer}
+          >
+            <Pressable
+              onPress={() => setSelectedGenre(null)}
+              style={[
+                styles.sortButton,
+                {
+                  backgroundColor: !selectedGenre ? colors.primary : colors.buttonBackground,
+                  borderColor: !selectedGenre ? colors.primary : colors.buttonBorder,
+                },
+              ]}
+            >
+              <Ionicons
+                name="pricetags-outline"
+                size={16}
+                color={!selectedGenre ? colors.background : colors.primary}
+              />
+              <ThemedText
+                style={[
+                  styles.sortButtonText,
+                  { color: !selectedGenre ? colors.background : colors.primaryText },
+                ]}
+                type="label"
+              >
+                All genres
+              </ThemedText>
+            </Pressable>
+            {availableGenres.map(({ genre, count }) => {
+              const isActive = selectedGenre === genre;
+              return (
+                <Pressable
+                  key={genre}
+                  onPress={() => setSelectedGenre(isActive ? null : genre)}
+                  style={[
+                    styles.sortButton,
+                    {
+                      backgroundColor: isActive ? colors.primary : colors.buttonBackground,
+                      borderColor: isActive ? colors.primary : colors.buttonBorder,
+                    },
+                  ]}
+                >
+                  <ThemedText
+                    style={[
+                      styles.sortButtonText,
+                      { color: isActive ? colors.background : colors.primaryText },
+                    ]}
+                    type="label"
+                  >
+                    {genre}
+                  </ThemedText>
+                  <ThemedText
+                    style={[
+                      styles.genreCount,
+                      {
+                        color: isActive ? colors.background : colors.secondaryText,
+                      },
+                    ]}
+                    type="caption"
+                  >
+                    {count}
+                  </ThemedText>
+                </Pressable>
+              );
+            })}
+          </ScrollView>
+        </View>
+      )}
+
       <View style={styles.header}>
         <ThemedText style={[styles.bookCount, { color: colors.secondaryText }]} type="body">
           {filteredBooks.length} {filteredBooks.length === 1 ? "book" : "books"}
         </ThemedText>
       </View>
+
+      {filteredBooks.length === 0 && (
+        <View style={styles.emptyContainer}>
+          <ThemedView
+            variant="card"
+            style={[styles.emptyState, { borderColor: colors.cardBorder }]}
+          >
+            <View
+              style={[styles.emptyIconContainer, { backgroundColor: colors.inactiveBackground }]}
+            >
+              <Ionicons name="filter-outline" size={48} color={colors.tertiaryText} />
+            </View>
+            <ThemedText style={[styles.emptyTitle, { color: colors.primaryText }]} type="heading">
+              No matches
+            </ThemedText>
+            <ThemedText style={[styles.emptySubtitle, { color: colors.secondaryText }]} type="body">
+              No books in {selectedGenre ? `"${selectedGenre}"` : "this filter"}. Try another genre.
+            </ThemedText>
+          </ThemedView>
+        </View>
+      )}
 
       <FlatList
         data={filteredBooks}
@@ -396,6 +519,14 @@ const styles = StyleSheet.create({
   sortContainer: {
     paddingHorizontal: 16,
     paddingVertical: 12,
+  },
+  genreContainer: {
+    paddingHorizontal: 16,
+    paddingBottom: 4,
+  },
+  genreCount: {
+    marginLeft: 4,
+    fontSize: 12,
   },
   sortButtonsContainer: {
     gap: 8,

--- a/lexicons/defs.json
+++ b/lexicons/defs.json
@@ -232,6 +232,11 @@
           "description": "External identifiers for the book",
           "type": "ref",
           "ref": "buzz.bookhive.defs#bookIdentifiers"
+        },
+        "genres": {
+          "type": "array",
+          "description": "Book genres",
+          "items": { "type": "string" }
         }
       }
     },

--- a/src/bsky/lexicon/generated/types/buzz/bookhive/defs.ts
+++ b/src/bsky/lexicon/generated/types/buzz/bookhive/defs.ts
@@ -193,6 +193,10 @@ const _userBookSchema = /*#__PURE__*/ v.object({
    */
   finishedAt: /*#__PURE__*/ v.optional(/*#__PURE__*/ v.datetimeString()),
   /**
+   * Book genres
+   */
+  genres: /*#__PURE__*/ v.optional(/*#__PURE__*/ v.array(/*#__PURE__*/ v.string())),
+  /**
    * The book's hive id, used to correlate user's books with the hive
    */
   hiveId: /*#__PURE__*/ v.string(),

--- a/src/xrpc/router.ts
+++ b/src/xrpc/router.ts
@@ -589,6 +589,8 @@ export function createXrpcRouter<E extends XrpcContext, V extends { ctx: E } = {
         profileIdRows.map((r) => [r.hiveId, toBookIdentifiersOutput(r)]),
       );
 
+      const genresByHiveId = await loadGenresMapForHiveBooks(ctx.db, profileHiveIds as HiveId[]);
+
       const didToHandle = await ctx.resolver.resolveDidsToHandles(
         Array.from(
           new Set(books.map((c) => c.userDid).concat(friendsBuzzes.map((r) => r.userDid))),
@@ -642,6 +644,7 @@ export function createXrpcRouter<E extends XrpcContext, V extends { ctx: E } = {
           startedAt: b.startedAt ?? undefined,
           bookProgress: b.bookProgress ?? undefined,
           identifiers: identifiersByHiveId.get(b.hiveId),
+          genres: genresByHiveId.get(b.hiveId as HiveId),
         })),
         books: parsedBooks.map((b) => ({
           userDid: b.userDid,
@@ -662,6 +665,7 @@ export function createXrpcRouter<E extends XrpcContext, V extends { ctx: E } = {
           startedAt: b.startedAt ?? undefined,
           bookProgress: b.bookProgress ?? undefined,
           identifiers: identifiersByHiveId.get(b.hiveId),
+          genres: genresByHiveId.get(b.hiveId as HiveId),
         })),
         activity: books
           .reduce(


### PR DESCRIPTION
## Summary
- Adds a horizontal genre-chip filter bar to the shelf list page in the mobile app (`/books/[status]`), so users browsing their Want-to-Read list (or any other status) can narrow down by genre — e.g. when standing in a bookshop looking for the next read. Chips show per-genre counts, sort by popularity within the shelf, and include an "All genres" reset.
- Threads genres end-to-end: adds optional `genres: string[]` to the `userBook` lexicon, regenerates types, and has `getProfile` hydrate each returned book (and `friendActivity` entry) with genres via the existing `loadGenresMapForHiveBooks` helper.

## Test plan
- [ ] Open the iOS app, navigate to Home → Want to Read, confirm the genre chip row renders above the book count with correct counts
- [ ] Tap a genre, confirm only books in that genre remain; tap "All genres" or the active chip again to clear
- [ ] Pick a genre with no matches to verify the "No matches" empty state
- [ ] Confirm the same filter works on Currently Reading, Finished, Abandoned, and Owned shelves
- [ ] Confirm shelves with no genre metadata don't render the chip row

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added genre filtering to book listings with a new genre selector displaying available genres and book counts
  * Sorting now applies after optional genre filtering
  * Improved empty-state messaging distinguishes between no books for the status and no books matching the selected genre filter

<!-- end of auto-generated comment: release notes by coderabbit.ai -->