### PR TITLE
feat: expose book metadata in hiveBook & catalogBook lexicons

### DIFF
--- a/lexicons/catalogBook.json
+++ b/lexicons/catalogBook.json
@@ -96,6 +96,48 @@
             "description": "External identifiers for the book",
             "type": "ref",
             "ref": "buzz.bookhive.defs#bookIdentifiers"
+          },
+          "language": {
+            "type": "string",
+            "description": "Human-readable language name (e.g. English)",
+            "maxLength": 64
+          },
+          "numPages": {
+            "type": "integer",
+            "description": "Total page count",
+            "minimum": 1
+          },
+          "publicationYear": {
+            "type": "integer",
+            "description": "Year of publication",
+            "minimum": 1,
+            "maximum": 9999
+          },
+          "publisher": {
+            "type": "string",
+            "description": "Publisher name",
+            "maxLength": 256
+          },
+          "authorBio": {
+            "type": "string",
+            "description": "Primary author biography",
+            "maxLength": 10000
+          },
+          "secondaryAuthors": {
+            "type": "array",
+            "description": "Additional contributors",
+            "items": {
+              "type": "ref",
+              "ref": "buzz.bookhive.defs#secondaryAuthor"
+            }
+          },
+          "ratingsDistribution": {
+            "type": "array",
+            "description": "Distribution of ratings (1-star through 5-star counts)",
+            "items": {
+              "type": "integer"
+            },
+            "maxLength": 5
           }
         }
       }

--- a/lexicons/defs.json
+++ b/lexicons/defs.json
@@ -278,6 +278,23 @@
         }
       }
     },
+    "secondaryAuthor": {
+      "type": "object",
+      "description": "A secondary contributor to a book",
+      "required": ["name"],
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Name of the contributor",
+          "maxLength": 256
+        },
+        "role": {
+          "type": "string",
+          "description": "Role of the contributor (e.g. 'Editor', 'Illustrator', 'Translator')",
+          "maxLength": 128
+        }
+      }
+    },
     "bookIdentifiers": {
       "type": "object",
       "description": "External identifiers for a book",

--- a/lexicons/hiveBook.json
+++ b/lexicons/hiveBook.json
@@ -80,6 +80,40 @@
               "type": "string"
             },
             "description": "Book genres"
+          },
+          "language": {
+            "type": "string",
+            "description": "Human-readable language name (e.g. English)",
+            "maxLength": 64
+          },
+          "numPages": {
+            "type": "integer",
+            "description": "Total page count",
+            "minimum": 1
+          },
+          "publicationYear": {
+            "type": "integer",
+            "description": "Year of publication",
+            "minimum": 1,
+            "maximum": 9999
+          },
+          "publisher": {
+            "type": "string",
+            "description": "Publisher name",
+            "maxLength": 256
+          },
+          "authorBio": {
+            "type": "string",
+            "description": "Primary author biography",
+            "maxLength": 10000
+          },
+          "secondaryAuthors": {
+            "type": "array",
+            "description": "Additional contributors",
+            "items": {
+              "type": "ref",
+              "ref": "buzz.bookhive.defs#secondaryAuthor"
+            }
           }
         }
       }

--- a/src/bsky/bookLookup.ts
+++ b/src/bsky/bookLookup.ts
@@ -22,6 +22,12 @@ export type HiveBookOutput = {
   sourceUrl?: string;
   identifiers?: BookIdentifiers;
   genres?: string[];
+  language?: string;
+  numPages?: number;
+  publicationYear?: number;
+  publisher?: string;
+  authorBio?: string;
+  secondaryAuthors?: Array<{ name: string; role?: string }>;
 };
 
 /**
@@ -33,6 +39,8 @@ export function toHiveBookOutput(
   identifiers: BookIdentifiers,
   genres?: string[],
 ): HiveBookOutput {
+  const meta = book.meta ? safeJsonParse<BookMeta>(book.meta) : null;
+
   return {
     $type: "buzz.bookhive.hiveBook",
     id: book.id,
@@ -50,7 +58,33 @@ export function toHiveBookOutput(
     sourceUrl: book.sourceUrl ?? undefined,
     identifiers,
     ...(genres && genres.length > 0 ? { genres } : {}),
+    language: book.language ?? undefined,
+    numPages: meta?.numPages && meta.numPages > 0 ? meta.numPages : undefined,
+    publicationYear:
+      meta?.publicationYear && meta.publicationYear > 0 ? meta.publicationYear : undefined,
+    publisher: meta?.publisher || undefined,
+    authorBio: meta?.authorBio || undefined,
+    secondaryAuthors:
+      meta?.secondaryAuthors && meta.secondaryAuthors.length > 0
+        ? meta.secondaryAuthors
+        : undefined,
   };
+}
+
+interface BookMeta {
+  publisher?: string;
+  publicationYear?: number;
+  numPages?: number;
+  authorBio?: string;
+  secondaryAuthors?: Array<{ name: string; role?: string }>;
+}
+
+function safeJsonParse<T>(json: string): T | null {
+  try {
+    return JSON.parse(json) as T;
+  } catch {
+    return null;
+  }
 }
 
 /**

--- a/src/bsky/lexicon/generated/types/buzz/bookhive/catalogBook.ts
+++ b/src/bsky/lexicon/generated/types/buzz/bookhive/catalogBook.ts
@@ -8,6 +8,13 @@ const _mainSchema = /*#__PURE__*/ v.record(
   /*#__PURE__*/ v.object({
     $type: /*#__PURE__*/ v.literal("buzz.bookhive.catalogBook"),
     /**
+     * Primary author biography
+     * @maxLength 10000
+     */
+    authorBio: /*#__PURE__*/ v.optional(
+      /*#__PURE__*/ v.constrain(/*#__PURE__*/ v.string(), [/*#__PURE__*/ v.stringLength(0, 10000)]),
+    ),
+    /**
      * The authors of the book (tab separated)
      * @minLength 1
      * @maxLength 512
@@ -53,6 +60,35 @@ const _mainSchema = /*#__PURE__*/ v.record(
       return /*#__PURE__*/ v.optional(BuzzBookhiveDefs.bookIdentifiersSchema);
     },
     /**
+     * Human-readable language name (e.g. English)
+     * @maxLength 64
+     */
+    language: /*#__PURE__*/ v.optional(
+      /*#__PURE__*/ v.constrain(/*#__PURE__*/ v.string(), [/*#__PURE__*/ v.stringLength(0, 64)]),
+    ),
+    /**
+     * Total page count
+     * @minimum 1
+     */
+    numPages: /*#__PURE__*/ v.optional(
+      /*#__PURE__*/ v.constrain(/*#__PURE__*/ v.integer(), [/*#__PURE__*/ v.integerRange(1)]),
+    ),
+    /**
+     * Year of publication
+     * @minimum 1
+     * @maximum 9999
+     */
+    publicationYear: /*#__PURE__*/ v.optional(
+      /*#__PURE__*/ v.constrain(/*#__PURE__*/ v.integer(), [/*#__PURE__*/ v.integerRange(1, 9999)]),
+    ),
+    /**
+     * Publisher name
+     * @maxLength 256
+     */
+    publisher: /*#__PURE__*/ v.optional(
+      /*#__PURE__*/ v.constrain(/*#__PURE__*/ v.string(), [/*#__PURE__*/ v.stringLength(0, 256)]),
+    ),
+    /**
      * Average rating (0-5000, where 1000 == 1.0)
      * @minimum 0
      * @maximum 5000
@@ -64,6 +100,23 @@ const _mainSchema = /*#__PURE__*/ v.record(
      * Number of ratings
      */
     ratingsCount: /*#__PURE__*/ v.optional(/*#__PURE__*/ v.integer()),
+    /**
+     * Distribution of ratings (1-star through 5-star counts)
+     * @maxLength 5
+     */
+    ratingsDistribution: /*#__PURE__*/ v.optional(
+      /*#__PURE__*/ v.constrain(/*#__PURE__*/ v.array(/*#__PURE__*/ v.integer()), [
+        /*#__PURE__*/ v.arrayLength(0, 5),
+      ]),
+    ),
+    /**
+     * Additional contributors
+     */
+    get secondaryAuthors() {
+      return /*#__PURE__*/ v.optional(
+        /*#__PURE__*/ v.array(BuzzBookhiveDefs.secondaryAuthorSchema),
+      );
+    },
     /**
      * Series name if the book is part of a series
      */

--- a/src/bsky/lexicon/generated/types/buzz/bookhive/defs.ts
+++ b/src/bsky/lexicon/generated/types/buzz/bookhive/defs.ts
@@ -160,6 +160,21 @@ const _reviewSchema = /*#__PURE__*/ v.object({
    */
   stars: /*#__PURE__*/ v.optional(/*#__PURE__*/ v.integer()),
 });
+const _secondaryAuthorSchema = /*#__PURE__*/ v.object({
+  $type: /*#__PURE__*/ v.optional(/*#__PURE__*/ v.literal("buzz.bookhive.defs#secondaryAuthor")),
+  /**
+   * Name of the contributor
+   * @maxLength 256
+   */
+  name: /*#__PURE__*/ v.constrain(/*#__PURE__*/ v.string(), [/*#__PURE__*/ v.stringLength(0, 256)]),
+  /**
+   * Role of the contributor (e.g. 'Editor', 'Illustrator', 'Translator')
+   * @maxLength 128
+   */
+  role: /*#__PURE__*/ v.optional(
+    /*#__PURE__*/ v.constrain(/*#__PURE__*/ v.string(), [/*#__PURE__*/ v.stringLength(0, 128)]),
+  ),
+});
 const _userBookSchema = /*#__PURE__*/ v.object({
   $type: /*#__PURE__*/ v.optional(/*#__PURE__*/ v.literal("buzz.bookhive.defs#userBook")),
   /**
@@ -280,6 +295,7 @@ type finished$schematype = typeof _finishedSchema;
 type profile$schematype = typeof _profileSchema;
 type reading$schematype = typeof _readingSchema;
 type review$schematype = typeof _reviewSchema;
+type secondaryAuthor$schematype = typeof _secondaryAuthorSchema;
 type userBook$schematype = typeof _userBookSchema;
 type wantToRead$schematype = typeof _wantToReadSchema;
 
@@ -292,6 +308,7 @@ export interface finishedSchema extends finished$schematype {}
 export interface profileSchema extends profile$schematype {}
 export interface readingSchema extends reading$schematype {}
 export interface reviewSchema extends review$schematype {}
+export interface secondaryAuthorSchema extends secondaryAuthor$schematype {}
 export interface userBookSchema extends userBook$schematype {}
 export interface wantToReadSchema extends wantToRead$schematype {}
 
@@ -304,6 +321,7 @@ export const finishedSchema = _finishedSchema as finishedSchema;
 export const profileSchema = _profileSchema as profileSchema;
 export const readingSchema = _readingSchema as readingSchema;
 export const reviewSchema = _reviewSchema as reviewSchema;
+export const secondaryAuthorSchema = _secondaryAuthorSchema as secondaryAuthorSchema;
 export const userBookSchema = _userBookSchema as userBookSchema;
 export const wantToReadSchema = _wantToReadSchema as wantToReadSchema;
 
@@ -316,5 +334,6 @@ export type Finished = v.InferInput<typeof finishedSchema>;
 export interface Profile extends v.InferInput<typeof profileSchema> {}
 export type Reading = v.InferInput<typeof readingSchema>;
 export interface Review extends v.InferInput<typeof reviewSchema> {}
+export interface SecondaryAuthor extends v.InferInput<typeof secondaryAuthorSchema> {}
 export interface UserBook extends v.InferInput<typeof userBookSchema> {}
 export type WantToRead = v.InferInput<typeof wantToReadSchema>;

--- a/src/bsky/lexicon/generated/types/buzz/bookhive/hiveBook.ts
+++ b/src/bsky/lexicon/generated/types/buzz/bookhive/hiveBook.ts
@@ -8,6 +8,13 @@ const _mainSchema = /*#__PURE__*/ v.record(
   /*#__PURE__*/ v.object({
     $type: /*#__PURE__*/ v.literal("buzz.bookhive.hiveBook"),
     /**
+     * Primary author biography
+     * @maxLength 10000
+     */
+    authorBio: /*#__PURE__*/ v.optional(
+      /*#__PURE__*/ v.constrain(/*#__PURE__*/ v.string(), [/*#__PURE__*/ v.stringLength(0, 10000)]),
+    ),
+    /**
      * The authors of the book (tab separated)
      * @minLength 1
      * @maxLength 512
@@ -42,6 +49,35 @@ const _mainSchema = /*#__PURE__*/ v.record(
       return /*#__PURE__*/ v.optional(BuzzBookhiveDefs.bookIdentifiersSchema);
     },
     /**
+     * Human-readable language name (e.g. English)
+     * @maxLength 64
+     */
+    language: /*#__PURE__*/ v.optional(
+      /*#__PURE__*/ v.constrain(/*#__PURE__*/ v.string(), [/*#__PURE__*/ v.stringLength(0, 64)]),
+    ),
+    /**
+     * Total page count
+     * @minimum 1
+     */
+    numPages: /*#__PURE__*/ v.optional(
+      /*#__PURE__*/ v.constrain(/*#__PURE__*/ v.integer(), [/*#__PURE__*/ v.integerRange(1)]),
+    ),
+    /**
+     * Year of publication
+     * @minimum 1
+     * @maximum 9999
+     */
+    publicationYear: /*#__PURE__*/ v.optional(
+      /*#__PURE__*/ v.constrain(/*#__PURE__*/ v.integer(), [/*#__PURE__*/ v.integerRange(1, 9999)]),
+    ),
+    /**
+     * Publisher name
+     * @maxLength 256
+     */
+    publisher: /*#__PURE__*/ v.optional(
+      /*#__PURE__*/ v.constrain(/*#__PURE__*/ v.string(), [/*#__PURE__*/ v.stringLength(0, 256)]),
+    ),
+    /**
      * Average rating (0-1000)
      * @minimum 0
      * @maximum 1000
@@ -53,6 +89,14 @@ const _mainSchema = /*#__PURE__*/ v.record(
      * Number of ratings
      */
     ratingsCount: /*#__PURE__*/ v.optional(/*#__PURE__*/ v.integer()),
+    /**
+     * Additional contributors
+     */
+    get secondaryAuthors() {
+      return /*#__PURE__*/ v.optional(
+        /*#__PURE__*/ v.array(BuzzBookhiveDefs.secondaryAuthorSchema),
+      );
+    },
     /**
      * The source service name (e.g. Goodreads)
      */

--- a/src/routes/admin.ts
+++ b/src/routes/admin.ts
@@ -176,6 +176,30 @@ const admin = new Hono<AppEnv>()
       return c.json({ message: "Internal server error" }, 500);
     }
   })
+  .post("/invalidate-catalog", async (c) => {
+    const ctx = c.get("ctx");
+    const authorization = c.req.header("authorization");
+    if (
+      !env.EXPORT_SHARED_SECRET ||
+      !isAuthorizedExportRequest({
+        authorizationHeader: authorization,
+        sharedSecret: env.EXPORT_SHARED_SECRET,
+      })
+    ) {
+      return c.json({ message: "Not Found" }, 404);
+    }
+
+    const result = await ctx.db
+      .updateTable("hive_book")
+      .set({ hiveBookCatalogUpdatedAt: null })
+      .where("enrichedAt", "is not", null)
+      .where("hiveBookAtUri", "is not", null)
+      .executeTakeFirst();
+
+    const count = Number(result.numUpdatedRows);
+    ctx.addWideEventContext({ invalidate_catalog: "completed", count });
+    return c.json({ message: "Catalog records invalidated", count });
+  })
   .post("/refresh-user-books", async (c) => {
     const ctx = c.get("ctx");
     const authorization = c.req.header("authorization");

--- a/src/utils/catalogBookService.ts
+++ b/src/utils/catalogBookService.ts
@@ -46,6 +46,15 @@ interface CatalogBlobs {
   coverBlob?: BlobRef;
 }
 
+interface CatalogBookMeta {
+  publisher?: string;
+  publicationYear?: number;
+  numPages?: number;
+  authorBio?: string;
+  secondaryAuthors?: Array<{ name: string; role?: string }>;
+  ratingsDistribution?: number[];
+}
+
 function safeJsonParse<T>(json: string, fallback: T, context: string): T {
   try {
     return JSON.parse(json) as T;
@@ -56,6 +65,10 @@ function safeJsonParse<T>(json: string, fallback: T, context: string): T {
 }
 
 function buildCatalogBookValue(book: HiveBook, blobs?: CatalogBlobs, catalogGenres?: string[]) {
+  const meta = book.meta
+    ? safeJsonParse<CatalogBookMeta>(book.meta, {} as CatalogBookMeta, `book ${book.id} meta`)
+    : null;
+
   return {
     $type: ids.BuzzBookhiveCatalogBook,
     id: book.id,
@@ -87,6 +100,19 @@ function buildCatalogBookValue(book: HiveBook, blobs?: CatalogBlobs, catalogGenr
             `book ${book.id} identifiers`,
           ),
         }
+      : {}),
+    ...(book.language ? { language: book.language } : {}),
+    ...(meta?.numPages && meta.numPages > 0 ? { numPages: meta.numPages } : {}),
+    ...(meta?.publicationYear && meta.publicationYear > 0
+      ? { publicationYear: meta.publicationYear }
+      : {}),
+    ...(meta?.publisher ? { publisher: meta.publisher } : {}),
+    ...(meta?.authorBio ? { authorBio: meta.authorBio } : {}),
+    ...(meta?.secondaryAuthors && meta.secondaryAuthors.length > 0
+      ? { secondaryAuthors: meta.secondaryAuthors }
+      : {}),
+    ...(meta?.ratingsDistribution && meta.ratingsDistribution.length > 0
+      ? { ratingsDistribution: meta.ratingsDistribution }
       : {}),
   };
 }


### PR DESCRIPTION
## Summary

- Adds 6 new optional fields to the `hiveBook` lexicon: `language`, `numPages`, `publicationYear`, `publisher`, `authorBio`, `secondaryAuthors` — promoting data previously trapped in the opaque `meta` JSON blob to first-class typed properties
- Adds the same 6 fields plus `ratingsDistribution` to the `catalogBook` lexicon
- Adds a `secondaryAuthor` shared def in `defs.json` for contributor entries (name + role)
- Updates `toHiveBookOutput()` and `buildCatalogBookValue()` to parse the `meta` JSON and populate the new fields in XRPC responses and catalog records
- Adds `POST /admin/invalidate-catalog` endpoint to null out `hiveBookCatalogUpdatedAt` for all synced books, so they get re-written with the new fields on next interaction or backfill

## Test plan
- [x] `bun run lexgen` succeeds
- [x] `bun run typecheck` passes
- [x] `bun test` — 172 tests pass
- [ ] Hit `/xrpc/buzz.bookhive.getBook?hiveId=<enriched-book-id>` and confirm new fields appear
- [ ] Call `POST /admin/invalidate-catalog` then `POST /admin/backfill-catalog` to re-sync catalog records

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Books now display additional metadata including language, page count, publication year, publisher details, and author biography
  * Added secondary author support with contributor role information
  * Enhanced ratings distribution tracking for improved insights

<!-- end of auto-generated comment: release notes by coderabbit.ai -->