### PR TITLE
fix: handle Goodreads exports without average rating

### DIFF
--- a/src/utils/csv.test.ts
+++ b/src/utils/csv.test.ts
@@ -106,6 +106,54 @@ describe("CSV Parsers", () => {
         privateNotes: "Private note",
       });
     });
+
+    it("should parse Goodreads exports when Average Rating column is absent", async () => {
+      const csvData = `Book Id,Title,Author,Author l-f,Additional Authors,ISBN,ISBN13,My Rating,Publisher,Binding,Number of Pages,Year Published,Original Publication Year,Date Read,Date Added,Bookshelves,Bookshelves with positions,Exclusive Shelf,My Review,Spoiler,Private Notes,Read Count,Owned Copies
+456,Future Reading,Example Author,"Author, Example",Second Author,"=""0123456789""","=""9780123456789""",0,Test Publisher,Hardcover,250,2024,2024,,2026/06/07,to-read,to-read (#158),to-read,,,,0,0`;
+
+      const parser = getGoodreadsCsvParser();
+      const stream = new ReadableStream({
+        start(controller) {
+          controller.enqueue(new TextEncoder().encode(csvData));
+          controller.close();
+        },
+      });
+
+      const books = [];
+      const reader = stream.pipeThrough(parser).getReader();
+
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        books.push(value);
+      }
+
+      expect(books).toHaveLength(1);
+      expect(books[0]).toMatchObject({
+        bookId: "456",
+        title: "Future Reading",
+        author: "Example Author",
+        authorLastFirst: "Author, Example",
+        additionalAuthors: ["Second Author"],
+        isbn: "0123456789",
+        isbn13: "9780123456789",
+        myRating: 0,
+        averageRating: 0,
+        publisher: "Test Publisher",
+        binding: "Hardcover",
+        numberOfPages: 250,
+        yearPublished: 2024,
+        originalPublicationYear: 2024,
+        dateRead: null,
+        bookshelves: ["to-read"],
+        bookshelvesWithPositions: "to-read (#158)",
+        exclusiveShelf: "to-read",
+        readCount: 0,
+        ownedCopies: 0,
+      });
+      expect(books[0]!.dateAdded).toBeInstanceOf(Date);
+      expect(books[0]!.dateAdded?.getFullYear()).toBe(2026);
+    });
   });
 
   describe("StoryGraph CSV Parser", () => {

--- a/src/utils/csv.ts
+++ b/src/utils/csv.ts
@@ -190,36 +190,39 @@ export function getStorygraphCsvParser() {
 }
 
 export function getGoodreadsCsvParser() {
+  const columns = [
+    "bookId",
+    "title",
+    "author",
+    "authorLastFirst",
+    "additionalAuthors",
+    "isbn",
+    "isbn13",
+    "myRating",
+    "averageRating",
+    "publisher",
+    "binding",
+    "numberOfPages",
+    "yearPublished",
+    "originalPublicationYear",
+    "dateRead",
+    "dateAdded",
+    "bookshelves",
+    "bookshelvesWithPositions",
+    "exclusiveShelf",
+    "myReview",
+    "spoiler",
+    "privateNotes",
+    "readCount",
+    "ownedCopies",
+  ];
+  const columnsWithoutAverageRating = columns.filter((column) => column !== "averageRating");
+
   const parser = parse({
     skip_empty_lines: true,
     trim: true,
-    from: 2,
-    columns: [
-      "bookId",
-      "title",
-      "author",
-      "authorLastFirst",
-      "additionalAuthors",
-      "isbn",
-      "isbn13",
-      "myRating",
-      "averageRating",
-      "publisher",
-      "binding",
-      "numberOfPages",
-      "yearPublished",
-      "originalPublicationYear",
-      "dateRead",
-      "dateAdded",
-      "bookshelves",
-      "bookshelvesWithPositions",
-      "exclusiveShelf",
-      "myReview",
-      "spoiler",
-      "privateNotes",
-      "readCount",
-      "ownedCopies",
-    ],
+    columns: (headers: string[]) =>
+      headers.includes("Average Rating") ? columns : columnsWithoutAverageRating,
     cast: (value: string, { column }): any => {
       // First handle the quoted values
       if (value.startsWith('="') && value.endsWith('"')) {
@@ -268,6 +271,7 @@ export function getGoodreadsCsvParser() {
         while ((record = parser.read() as GoodreadsBook)) {
           // Validate the record before enqueueing
           if (record && record.title && record.author) {
+            record.averageRating ??= 0;
             controller.enqueue(record);
           } else {
             console.warn("Skipping invalid Goodreads record:", record);
@@ -287,6 +291,7 @@ export function getGoodreadsCsvParser() {
         while ((record = parser.read() as GoodreadsBook)) {
           // Validate the record before enqueueing
           if (record && record.title && record.author) {
+            record.averageRating ??= 0;
             controller.enqueue(record);
           } else {
             console.warn("Skipping invalid Goodreads record during flush:", record);

--- a/src/utils/importBook.test.ts
+++ b/src/utils/importBook.test.ts
@@ -386,6 +386,34 @@ describe("importBook utilities", () => {
       });
       expect(result.coverImage).toBeUndefined();
     });
+
+    it("does not set finishedAt when status is reading even if dateRead exists", () => {
+      const book = makeGoodreadsBook({
+        exclusiveShelf: "currently-reading",
+        dateRead: new Date("2024-06-15"),
+      });
+      const result = buildGoodreadsBookRecord({
+        book,
+        hiveBook,
+        existingHiveIds: new Set(),
+      });
+      expect(result.status).toBe("buzz.bookhive.defs#reading");
+      expect(result.finishedAt).toBeUndefined();
+    });
+
+    it("does not set finishedAt when status is wantToRead even if dateRead exists", () => {
+      const book = makeGoodreadsBook({
+        exclusiveShelf: "to-read",
+        dateRead: new Date("2024-06-15"),
+      });
+      const result = buildGoodreadsBookRecord({
+        book,
+        hiveBook,
+        existingHiveIds: new Set(),
+      });
+      expect(result.status).toBe("buzz.bookhive.defs#wantToRead");
+      expect(result.finishedAt).toBeUndefined();
+    });
   });
 
   describe("buildStorygraphBookRecord", () => {
@@ -446,6 +474,20 @@ describe("importBook utilities", () => {
         existingHiveIds: new Set(),
       });
       expect(result.stars).toBe(7);
+    });
+
+    it("does not set finishedAt when status is reading even if lastDateRead exists", () => {
+      const book = makeStorygraphBook({
+        readStatus: "currently-reading",
+        lastDateRead: new Date("2024-03-10"),
+      });
+      const result = buildStorygraphBookRecord({
+        book,
+        hiveBook,
+        existingHiveIds: new Set(),
+      });
+      expect(result.status).toBe("buzz.bookhive.defs#reading");
+      expect(result.finishedAt).toBeUndefined();
     });
   });
 

--- a/src/utils/importBook.test.ts
+++ b/src/utils/importBook.test.ts
@@ -105,13 +105,19 @@ describe("importBook utilities", () => {
       );
     });
 
-    it("returns finished when dateRead is set even if shelf is currently-reading", () => {
+    it("returns reading when exclusiveShelf is currently-reading even if dateRead is set", () => {
       expect(
         mapGoodreadsStatus({
           dateRead: new Date("2024-01-15"),
           exclusiveShelf: "currently-reading",
         }),
-      ).toBe("buzz.bookhive.defs#finished");
+      ).toBe("buzz.bookhive.defs#reading");
+    });
+
+    it("returns wantToRead when exclusiveShelf is to-read even if dateRead is set", () => {
+      expect(
+        mapGoodreadsStatus({ dateRead: new Date("2024-01-15"), exclusiveShelf: "to-read" }),
+      ).toBe("buzz.bookhive.defs#wantToRead");
     });
 
     it("returns reading when exclusiveShelf is currently-reading and no dateRead", () => {
@@ -325,6 +331,7 @@ describe("importBook utilities", () => {
     it("builds a full record for a read book", () => {
       const book = makeGoodreadsBook({
         dateRead: new Date("2024-06-15"),
+        exclusiveShelf: "read",
         myRating: 4,
         myReview: "Loved it",
         ownedCopies: 1,

--- a/src/utils/importBook.ts
+++ b/src/utils/importBook.ts
@@ -9,9 +9,16 @@ export function normalizeStr(s: string): string {
 export function mapGoodreadsStatus(
   book: Pick<GoodreadsBook, "dateRead" | "exclusiveShelf">,
 ): string {
-  if (book.dateRead) return "buzz.bookhive.defs#finished";
-  if (book.exclusiveShelf === "currently-reading") return "buzz.bookhive.defs#reading";
-  return "buzz.bookhive.defs#wantToRead";
+  switch (book.exclusiveShelf?.toLowerCase()) {
+    case "read":
+      return "buzz.bookhive.defs#finished";
+    case "currently-reading":
+      return "buzz.bookhive.defs#reading";
+    case "to-read":
+      return "buzz.bookhive.defs#wantToRead";
+    default:
+      return book.dateRead ? "buzz.bookhive.defs#finished" : "buzz.bookhive.defs#wantToRead";
+  }
 }
 
 export function mapStorygraphStatus(book: Pick<StorygraphBook, "readStatus">): string {

--- a/src/utils/importBook.ts
+++ b/src/utils/importBook.ts
@@ -102,13 +102,17 @@ export function buildGoodreadsBookRecord(params: {
   existingHiveIds: Set<string>;
 }) {
   const { book, hiveBook, existingHiveIds } = params;
+  const status = mapGoodreadsStatus(book);
   return {
     authors: book.author,
     title: hiveBook.title,
-    status: mapGoodreadsStatus(book),
+    status,
     hiveId: hiveBook.id,
     coverImage: hiveBook.cover ?? undefined,
-    finishedAt: book.dateRead?.toISOString() ?? undefined,
+    finishedAt:
+      status === "buzz.bookhive.defs#finished"
+        ? (book.dateRead?.toISOString() ?? undefined)
+        : undefined,
     stars: normalizeGoodreadsRating(book.myRating),
     review: book.myReview || undefined,
     owned: book.ownedCopies > 0 ? true : undefined,
@@ -122,13 +126,17 @@ export function buildStorygraphBookRecord(params: {
   existingHiveIds: Set<string>;
 }) {
   const { book, hiveBook, existingHiveIds } = params;
+  const status = mapStorygraphStatus(book);
   return {
     authors: book.authors,
     title: hiveBook.title,
-    status: mapStorygraphStatus(book),
+    status,
     hiveId: hiveBook.id,
     coverImage: hiveBook.cover ?? undefined,
-    finishedAt: book.lastDateRead?.toISOString() ?? undefined,
+    finishedAt:
+      status === "buzz.bookhive.defs#finished"
+        ? (book.lastDateRead?.toISOString() ?? undefined)
+        : undefined,
     stars: normalizeStorygraphRating(book.starRating),
     review: book.review || undefined,
     owned: book.owned ? true : undefined,


### PR DESCRIPTION
Partially addresses #147.

This fixes Goodreads CSV imports where the export is missing the `Average Rating` column, which caused later fields to shift and `to-read` books to be imported as read. It does not address the reported large-import stalling behavior.

Apparently goodreads removed "Average Rating" from the export at some point (at least it was removed from my recent export).

This was AI generated but I did try to review it to prevent it from doing anything particularly wacky. Also, hopefully it helps that the change is pretty small. But feel free to close without merging if you feel like it's poorly crafted.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved Goodreads CSV importing when the “Average Rating” column is missing—ratings now correctly default to 0.
  * Enhanced import status mapping for Goodreads and related records using shelf/status classification, and corrected handling of completion dates so they’re only set for completed statuses (not for “currently reading” or “to-read”).
* **Tests**
  * Added/updated unit tests to cover missing-rating CSVs and the corrected status/date behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->