### PR TITLE
docs: bun commands, latest architecture

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,38 +46,32 @@ Have a feature request? [Open an issue](https://github.com/nperez0111/bookhive/i
 To install dependencies:
 
 ```bash
-pnpm install
+bun install
 ```
 
-Copy `.env.example` to `.env` and fill in the values.
+Copy `.env.template` to `.env` and fill in the values.
 
 To run:
 
 ```bash
-pnpm run dev
+bun run dev
 ```
 
 ## Running Tests
 
 ```bash
 # Run all tests
-pnpm test
+bun run test
 
-# Run tests in watch mode
-pnpm test
-
-# Run tests once
-pnpm test:run
-
-# Run tests with UI
-pnpm test:ui
+# Run tests
+bun run test:run
 ```
 
 ## 🏗️ Architecture
 
 - **Backend**: [Hono](https://hono.dev) with AT Proto for OAuth
 - **Frontend**: Mostly static HTML, with some Hono JSX for dynamic content (Fast as possible)
-- **Database**: SQLite, with Kyesly as the ORM
+- **Database**: SQLite, with Kysely as the ORM
 
 ## 🗄️ Weekly database export (GitHub Actions artifact)
 


### PR DESCRIPTION
Updates the readme with a bit of new information for getting started with a typo fix:

- Fix the name of the provided .env, which is `.env.template` and not `.env.example`
- Update `pnpm` commands to `bun`
- Fix spelling of Kysely

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated setup instructions to use Bun instead of pnpm for package installation and development
  * Updated environment file reference from `.env.example` to `.env.template`
  * Revised test command examples for new tooling

* **Bug Fixes**
  * Corrected database ORM name in architecture documentation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->