### PR TITLE
fix: proxy app.bsky.* queries via atproto-proxy

### DIFF
--- a/src/context.ts
+++ b/src/context.ts
@@ -372,7 +372,7 @@ export function createContextMiddleware(deps: AppDeps) {
         deps.kv,
         "profile:" + did,
         async () => {
-          // Cache miss — need a full session to call the Bluesky API.
+          // Cache miss — need a full session to call the Bluesky AppView via PDS proxy.
           startTime(c, "get_profile_session");
           const client = await sessionLazy.value;
           endTime(c, "get_profile_session");
@@ -381,6 +381,7 @@ export function createContextMiddleware(deps: AppDeps) {
           try {
             const res = await client.get("app.bsky.actor.getProfile", {
               params: { actor: client.did as ActorIdentifier },
+              headers: { "atproto-proxy": "did:web:api.bsky.app#bsky_appview" },
             });
             if (!res.ok) return null;
             return res.data as ProfileViewDetailed | null;

--- a/src/utils/getFollows.ts
+++ b/src/utils/getFollows.ts
@@ -111,6 +111,7 @@ async function fullFollowsSync(
           limit: 100,
           cursor,
         },
+        headers: { "atproto-proxy": "did:web:api.bsky.app#bsky_appview" },
       });
     } catch (error) {
       ctx.addWideEventContext({
@@ -196,6 +197,7 @@ async function incrementalFollowsSync(
         limit: 100,
         cursor,
       },
+      headers: { "atproto-proxy": "did:web:api.bsky.app#bsky_appview" },
     });
     if (!response.ok) break;
     type GetFollowsOut = {

--- a/src/utils/getProfile.ts
+++ b/src/utils/getProfile.ts
@@ -29,6 +29,7 @@ export async function getProfile({
         const res = sessionClient
           ? await sessionClient.get("app.bsky.actor.getProfile", {
               params: { actor: actorParam },
+              headers: { "atproto-proxy": "did:web:api.bsky.app#bsky_appview" },
             })
           : await client.get("app.bsky.actor.getProfile", {
               params: { actor: actorParam },
@@ -71,6 +72,7 @@ export async function getProfiles({
     const res = sessionClient
       ? await sessionClient.get("app.bsky.actor.getProfiles", {
           params: { actors: actorsParam },
+          headers: { "atproto-proxy": "did:web:api.bsky.app#bsky_appview" },
         })
       : await client.get("app.bsky.actor.getProfiles", {
           params: { actors: actorsParam },


### PR DESCRIPTION
`app.bsky.actor.getProfile` and `app.bsky.graph.getFollows` are two XRPC queries called to the user's Personal Data Server during a session. The Bluesky Personal Data Server reference implementation implements this XRPC endpoint, proxying the request to the Bluesky Appview. This works fine for most users because most users are on a Bluesky PDS. However, some PDS implementation do not implement this, preferring to implement the specification and rely on the `atproto-proxy` header to tell a PDS where to proxy a call to. For those users, these calls will return something like a 501 Not Implemented. In practice, this means that `/home` will think the user is no longer authenticated, redirecting them to `/`. `/` will, in turn, think the user is authenticated, forwarding them to `/home`, and the user will get stuck in a redirect loop.

There are a few calls made to `app.bsky.*` queries where the `atproto-proxy` header has been placed to resolve this issue for users with PDSs that follow the spec.

This has been manually verified by myself, as I'm on such a PDS.

Edit: Meant to put this in the pull request description but cool project! I look forward to using it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated request routing for profile data retrieval and follows synchronization to improve request handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->