### PR TITLE
fix: correct request-tracing property, tighten type safety, and unref cleanup timer

### DIFF
--- a/app/components/GradientView.tsx
+++ b/app/components/GradientView.tsx
@@ -48,11 +48,11 @@ export function GradientView({
 
   return (
     <LinearGradient
-      colors={getGradientColors() as any}
+      colors={getGradientColors() as unknown as readonly [string, string, ...string[]]}
       start={start}
       end={end}
       style={[styles.container, StyleSheet.flatten([{ borderRadius: 24 }, style])]}
-      {...(restProps as any)}
+      {...restProps}
     >
       {children}
     </LinearGradient>

--- a/server/plugins/request-tracing.ts
+++ b/server/plugins/request-tracing.ts
@@ -25,9 +25,9 @@ export default definePlugin((nitroApp) => {
   const spans = new WeakMap<object, { span: Span; start: number }>();
 
   nitroApp.hooks.hook("request", (event) => {
-    // Nitro's HTTPEvent types are incomplete; the underlying Fetch Request is
-    // available at runtime but not exposed in the type declarations.
-    const req = (event as unknown as { request: Request }).request;
+    // Nitro's HTTPEvent types are incomplete; h3 v2 exposes the Fetch Request
+    // as `req` at runtime but the type declarations omit it.
+    const req = (event as unknown as { req: Request }).req;
     const url = new URL(req.url);
 
     if (shouldSkip(url.pathname)) return;

--- a/src/context.ts
+++ b/src/context.ts
@@ -168,19 +168,19 @@ export async function createAppDeps(): Promise<AppDeps> {
     // Expire old cached pages so a bot sweep of the long tail can't grow the
     // KV file unboundedly. 2x TTL keeps recently-stale rows around for cheap
     // overwrite instead of insert.
-    setInterval(
+    const pageCacheTimer = setInterval(
       () => {
         const cutoff = new Date(Date.now() - 2 * PAGE_CACHE_TTL_MS).toISOString();
         void sql`DELETE FROM page_cache WHERE updated_at < ${cutoff}`
           .execute(kvDb)
           .catch((e: any) => {
-            // "no such table" is expected on a fresh KV file before the first cache write
             if (String(e?.message).includes("no such table")) return;
             logger.error({ err: e }, "page_cache cleanup failed");
           });
       },
       15 * 60 * 1000,
     );
+    pageCacheTimer.unref();
   }
 
   const oauthClient = await createOAuthClient(kv);

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -92,7 +92,7 @@ function devImageProxyPassthrough(): Plugin {
   };
 }
 
-// eslint-disable-next-line -- vite-plus extends the config type beyond what defineConfig accepts
+// eslint-disable-next-line @typescript-eslint/no-explicit-any -- vite-plus extends the config type beyond what defineConfig accepts
 export default defineConfig(({ command }): any => ({
   staged: {
     "*": "vp check --fix",


### PR DESCRIPTION
## Summary

- **Fix runtime bug in request-tracing**: `event.request` → `event.req` to match h3 v2's actual API — the old property was undefined, silently breaking all OpenTelemetry spans
- **Tighten GradientView types**: replace broad `as any` casts with a targeted tuple assertion for LinearGradient's `colors` prop and remove the unnecessary `as any` on `restProps`
- **Unref page-cache cleanup timer**: call `.unref()` on the `setInterval` in `createAppDeps` so it no longer blocks graceful shutdown on the primary worker
- **Narrow lint suppression**: scope `eslint-disable-next-line` in `vite.config.ts` to only `@typescript-eslint/no-explicit-any` so other rules remain active

## Test plan

- [x] Both tsconfigs type-check clean (`bunx tsc --noEmit`)
- [x] All 198 tests pass (`bun test src`)
- [ ] Verify OpenTelemetry spans appear in traces after deploying the request-tracing fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved request tracing behavior to use the correct runtime request reference, helping maintain more reliable logging and error capture.
  * Prevented a background timer from keeping the process alive unnecessarily, improving cleanup behavior in long-running sessions.

* **Style**
  * Tightened type handling in gradient rendering for safer component props.
  * Simplified configuration typing by adjusting a lint-related suppression.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->