### PR TITLE
feat: add AT Tags to book, profile, and shelf pages

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -210,19 +210,19 @@ Each file exports a Hono JSX component rendered server-side.
 
 ### Shared Page Components (`src/pages/components/`)
 
-| File                       | What                                                                                          |
-| -------------------------- | --------------------------------------------------------------------------------------------- |
-| `book.tsx`                 | Book card component                                                                           |
-| `BookCard.tsx`             | Composable book card                                                                          |
-| `buzz.tsx`                 | Buzz/comment display                                                                          |
-| `BookReview.tsx`           | Book review form/display                                                                      |
-| `EditableLibraryTable.tsx` | Library table with inline editing                                                             |
-| `ProfileHeader.tsx`        | Profile header with avatar/stats                                                              |
-| `LanguageSelect.tsx`       | Language picker (search/explore filters)                                                      |
-| `modal.tsx`                | Modal dialog (CSS-based)                                                                      |
-| `fallbackCover.tsx`        | Placeholder book cover                                                                        |
-| `AtTags.tsx`               | [AT Tags](https://tangled.org/chrisshank.com/at-tags/) `<meta at:...>` builder (see below)    |
-| `cards/`                   | Sub-components: `Card.tsx`, `CardActions.tsx`, `StarDisplay.tsx`, `UserBlock.tsx`, `index.ts` |
+| File                       | What                                                                                              |
+| -------------------------- | ------------------------------------------------------------------------------------------------- |
+| `book.tsx`                 | Book card component                                                                               |
+| `BookCard.tsx`             | Composable book card                                                                              |
+| `buzz.tsx`                 | Buzz/comment display                                                                              |
+| `BookReview.tsx`           | Book review form/display                                                                          |
+| `EditableLibraryTable.tsx` | Library table with inline editing                                                                 |
+| `ProfileHeader.tsx`        | Profile header with avatar/stats                                                                  |
+| `LanguageSelect.tsx`       | Language picker (search/explore filters)                                                          |
+| `modal.tsx`                | Modal dialog (CSS-based)                                                                          |
+| `fallbackCover.tsx`        | Placeholder book cover                                                                            |
+| `AtTags.tsx`               | [AT Tags](https://tangled.org/chrisshank.com/at-tags/) `<meta name="at:...">` builder (see below) |
+| `cards/`                   | Sub-components: `Card.tsx`, `CardActions.tsx`, `StarDisplay.tsx`, `UserBlock.tsx`, `index.ts`     |
 
 Inline JS helper: `src/pages/utils/script.ts`
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -221,9 +221,22 @@ Each file exports a Hono JSX component rendered server-side.
 | `LanguageSelect.tsx`       | Language picker (search/explore filters)                                                      |
 | `modal.tsx`                | Modal dialog (CSS-based)                                                                      |
 | `fallbackCover.tsx`        | Placeholder book cover                                                                        |
+| `AtTags.tsx`               | [AT Tags](https://tangled.org/chrisshank.com/at-tags/) `<meta at:...>` builder (see below)    |
 | `cards/`                   | Sub-components: `Card.tsx`, `CardActions.tsx`, `StarDisplay.tsx`, `UserBlock.tsx`, `index.ts` |
 
 Inline JS helper: `src/pages/utils/script.ts`
+
+**AT Tags** (`AtTags.tsx`): emits `<meta name="at:...">` tags declaring which
+ATProto records/identities a page maps to ([proposal](https://tangled.org/chrisshank.com/at-tags/)).
+`Layout` (`src/pages/layout.tsx`) always emits a site-wide `at:me` (the
+`BOOKHIVE_DID` constant in `src/constants.ts`, also served at
+`/.well-known/atproto-did`) and renders per-page tags from its `atTags?: AtTagsProps`
+prop, which routes pass via `c.render(..., { atTags })` (the `ContextRenderer`
+type in `src/routes/main.tsx` carries it). Currently set on: book detail
+(`at:canonical` → `hive_book.hiveBookAtUri`), profile (`at:author` → DID), and
+shelf view (`at:canonical` → list AT URI, `at:author` → owner DID). Built with
+hono's `html` template, **not** JSX `<meta>` elements, because hono/jsx dedupes
+head `<meta>` tags by `name` and would collapse the proposal's array semantics.
 
 ## Client-Side Components (`src/client/`)
 

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -29,3 +29,6 @@ export const BOOK_STATUS_PAST_TENSE_MAP = {
   [WANTTOREAD]: "wants to read this book",
   [FINISHED]: "has read this book",
 } as const;
+
+/** DID of the @bookhive.buzz service account / site identity. */
+export const BOOKHIVE_DID = "did:plc:enu2j5xjlqsjaylv3du4myh4";

--- a/src/pages/components/AtTags.test.tsx
+++ b/src/pages/components/AtTags.test.tsx
@@ -1,0 +1,78 @@
+import { describe, it, expect } from "bun:test";
+
+import { AtTags, type AtTagsProps } from "./AtTags";
+
+/** Render AtTags to its HTML string. */
+function render(props: AtTagsProps): string {
+  return String(AtTags(props));
+}
+
+/** Extract [name, content] pairs from the rendered `<meta at:...>` tags. */
+function metas(html: string): Array<[string, string]> {
+  const pairs: Array<[string, string]> = [];
+  const re = /<meta name="(at:[^"]+)" content="([^"]*)"/g;
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(html))) {
+    pairs.push([m[1]!, m[2]!]);
+  }
+  return pairs;
+}
+
+describe("AtTags", () => {
+  it("emits nothing when given no values", () => {
+    expect(metas(render({}))).toEqual([]);
+  });
+
+  it("renders canonical and alternate records", () => {
+    const html = render({
+      canonical: "at://did:plc:x/buzz.bookhive.catalogBook/1",
+      alternate: "at://did:plc:y/buzz.bookhive.buzz/2",
+    });
+    expect(metas(html)).toEqual([
+      ["at:canonical", "at://did:plc:x/buzz.bookhive.catalogBook/1"],
+      ["at:alternate", "at://did:plc:y/buzz.bookhive.buzz/2"],
+    ]);
+  });
+
+  it("follows array semantics — one tag per value", () => {
+    const html = render({ canonical: ["at://did:plc:a/c/1", "at://did:plc:b/c/2"] });
+    expect(metas(html)).toEqual([
+      ["at:canonical", "at://did:plc:a/c/1"],
+      ["at:canonical", "at://did:plc:b/c/2"],
+    ]);
+  });
+
+  it("wraps bare DIDs as at:// URIs for author and me", () => {
+    const html = render({ author: "did:plc:author", me: "did:plc:site" });
+    expect(metas(html)).toEqual([
+      ["at:author", "at://did:plc:author"],
+      ["at:me", "at://did:plc:site"],
+    ]);
+  });
+
+  it("leaves already-qualified DID URIs untouched", () => {
+    const html = render({ author: "at://did:plc:author" });
+    expect(metas(html)).toEqual([["at:author", "at://did:plc:author"]]);
+  });
+
+  it("drops falsy/empty values (e.g. a null hiveBookAtUri)", () => {
+    expect(metas(render({ canonical: null }))).toEqual([]);
+    expect(metas(render({ canonical: undefined }))).toEqual([]);
+    expect(metas(render({ canonical: "   " }))).toEqual([]);
+    expect(metas(render({ canonical: ["at://did:plc:a/c/1", "", null] }))).toEqual([
+      ["at:canonical", "at://did:plc:a/c/1"],
+    ]);
+  });
+
+  it("dedupes repeated values", () => {
+    const html = render({ alternate: ["at://did:plc:a/c/1", "at://did:plc:a/c/1"] });
+    expect(metas(html)).toEqual([["at:alternate", "at://did:plc:a/c/1"]]);
+  });
+
+  it("emits namespaced custom properties", () => {
+    const html = render({
+      custom: { "blog:comments": "at://did:plc:a/app.bsky.feed.post/1" },
+    });
+    expect(metas(html)).toEqual([["at:blog:comments", "at://did:plc:a/app.bsky.feed.post/1"]]);
+  });
+});

--- a/src/pages/components/AtTags.test.tsx
+++ b/src/pages/components/AtTags.test.tsx
@@ -64,6 +64,17 @@ describe("AtTags", () => {
     ]);
   });
 
+  it("dedupes equivalent DID representations after normalization", () => {
+    const html = render({
+      author: ["did:plc:author", "at://did:plc:author"],
+      me: ["at://did:plc:site", "did:plc:site"],
+    });
+    expect(metas(html)).toEqual([
+      ["at:author", "at://did:plc:author"],
+      ["at:me", "at://did:plc:site"],
+    ]);
+  });
+
   it("dedupes repeated values", () => {
     const html = render({ alternate: ["at://did:plc:a/c/1", "at://did:plc:a/c/1"] });
     expect(metas(html)).toEqual([["at:alternate", "at://did:plc:a/c/1"]]);

--- a/src/pages/components/AtTags.tsx
+++ b/src/pages/components/AtTags.tsx
@@ -1,0 +1,85 @@
+import { html } from "hono/html";
+import { type HtmlEscapedString } from "hono/utils/html";
+
+/**
+ * AT Tags — declare which ATProto records/identities a web page corresponds to.
+ *
+ * Implements the community proposal at https://tangled.org/chrisshank.com/at-tags/
+ * Renders `<meta name="at:{prop}" content="{at-uri}">` tags. `<meta>` (not
+ * `<link>`) is used because AT URIs are not technically valid URIs and break
+ * HTML validation inside `<link>`.
+ *
+ * Built with hono's `html` template rather than JSX `<meta>` elements because
+ * hono/jsx deduplicates head `<meta>` tags by `name`, which would collapse the
+ * proposal's array semantics (e.g. multiple `at:canonical`).
+ *
+ * All properties follow array semantics: multiple values emit multiple tags.
+ * - `canonical` — the record(s) this page *is* (deleting them removes the page)
+ * - `alternate` — auxiliary record(s) referenced (page survives their deletion)
+ * - `author`    — DID(s) that authored the page (content is `at://did:...`)
+ * - `me`        — DID(s) that own the overall site/section (content is `at://did:...`)
+ * - `custom`    — namespaced props keyed `"ns:prop"` → `name="at:ns:prop"`
+ */
+
+type MaybeList = string | null | undefined | (string | null | undefined)[];
+
+export type AtTagsProps = {
+  canonical?: MaybeList;
+  alternate?: MaybeList;
+  /** DID or `at://did` — bare DIDs are normalized to `at://did`. */
+  author?: MaybeList;
+  /** DID or `at://did` — bare DIDs are normalized to `at://did`. */
+  me?: MaybeList;
+  /** Namespaced custom properties. Key `"ns:prop"` → `name="at:ns:prop"`. */
+  custom?: Record<string, MaybeList>;
+};
+
+/** Flatten to a deduped array of non-empty strings. */
+function clean(value: MaybeList): string[] {
+  const arr = Array.isArray(value) ? value : [value];
+  const seen = new Set<string>();
+  for (const v of arr) {
+    const s = v?.trim();
+    if (s) seen.add(s);
+  }
+  return [...seen];
+}
+
+/** DIDs (`did:...`) must be expressed as AT URIs (`at://did:...`) in content. */
+function toDidUri(value: string): string {
+  return value.startsWith("did:") ? `at://${value}` : value;
+}
+
+export const AtTags = ({
+  canonical,
+  alternate,
+  author,
+  me,
+  custom,
+}: AtTagsProps): HtmlEscapedString | Promise<HtmlEscapedString> => {
+  const tags: Array<{ name: string; content: string }> = [];
+
+  for (const content of clean(canonical)) {
+    tags.push({ name: "at:canonical", content });
+  }
+  for (const content of clean(alternate)) {
+    tags.push({ name: "at:alternate", content });
+  }
+  for (const content of clean(author)) {
+    tags.push({ name: "at:author", content: toDidUri(content) });
+  }
+  for (const content of clean(me)) {
+    tags.push({ name: "at:me", content: toDidUri(content) });
+  }
+  if (custom) {
+    for (const [key, value] of Object.entries(custom)) {
+      for (const content of clean(value)) {
+        tags.push({ name: `at:${key}`, content });
+      }
+    }
+  }
+
+  // hono renders an array of `html` fragments without re-escaping each one, and
+  // the interpolations here are auto-escaped (see layout.tsx's link/meta maps).
+  return html`${tags.map((t) => html`<meta name="${t.name}" content="${t.content}" />`)}`;
+};

--- a/src/pages/components/AtTags.tsx
+++ b/src/pages/components/AtTags.tsx
@@ -34,13 +34,17 @@ export type AtTagsProps = {
   custom?: Record<string, MaybeList>;
 };
 
-/** Flatten to a deduped array of non-empty strings. */
-function clean(value: MaybeList): string[] {
+/**
+ * Flatten to a deduped array of non-empty strings. An optional `transform` is
+ * applied before dedup so equivalent representations collapse (e.g. `did:x` and
+ * `at://did:x` both normalize to `at://did:x` and yield a single value).
+ */
+function clean(value: MaybeList, transform?: (s: string) => string): string[] {
   const arr = Array.isArray(value) ? value : [value];
   const seen = new Set<string>();
   for (const v of arr) {
     const s = v?.trim();
-    if (s) seen.add(s);
+    if (s) seen.add(transform ? transform(s) : s);
   }
   return [...seen];
 }
@@ -65,11 +69,11 @@ export const AtTags = ({
   for (const content of clean(alternate)) {
     tags.push({ name: "at:alternate", content });
   }
-  for (const content of clean(author)) {
-    tags.push({ name: "at:author", content: toDidUri(content) });
+  for (const content of clean(author, toDidUri)) {
+    tags.push({ name: "at:author", content });
   }
-  for (const content of clean(me)) {
-    tags.push({ name: "at:me", content: toDidUri(content) });
+  for (const content of clean(me, toDidUri)) {
+    tags.push({ name: "at:me", content });
   }
   if (custom) {
     for (const [key, value] of Object.entries(custom)) {

--- a/src/pages/layout.tsx
+++ b/src/pages/layout.tsx
@@ -3,6 +3,9 @@ import { html, raw } from "hono/html";
 import { type FC, type PropsWithChildren } from "hono/jsx";
 import { useRequestContext } from "hono/jsx-renderer";
 
+import { BOOKHIVE_DID } from "../constants";
+import { AtTags, type AtTagsProps } from "./components/AtTags";
+
 type BundleAssetUrls = { css: string[]; js: string[]; inlineCss?: string } | null;
 
 export const Layout: FC<
@@ -15,6 +18,8 @@ export const Layout: FC<
     url?: string;
     ogType?: string;
     ogExtra?: any;
+    /** AT Tags — ATProto records/identities this page corresponds to. */
+    atTags?: AtTagsProps;
   }>
 > = ({
   children,
@@ -25,6 +30,7 @@ export const Layout: FC<
   url: urlProp,
   ogType = "website",
   ogExtra,
+  atTags,
 }) => {
   let url = urlProp ?? "https://bookhive.buzz";
   let assetUrls = assetUrlsProp;
@@ -89,6 +95,8 @@ export const Layout: FC<
         <meta property="og:image" content="${image}" />
         <meta property="og:logo" content="/icon.svg" />
         ${ogExtra}
+        <meta name="at:me" content="${`at://${BOOKHIVE_DID}`}" />
+        ${AtTags(atTags ?? {})}
         <meta name="twitter:card" content="summary_large_image" />
         <meta property="twitter:domain" content="bookhive.buzz" />
         <meta property="twitter:url" content="${url}" />

--- a/src/routes/books.tsx
+++ b/src/routes/books.tsx
@@ -99,7 +99,8 @@ const app = new Hono<AppEnv>()
           {isbn && <meta property="book:isbn" content={isbn} />}
         </>
       ),
-    } as any);
+      atTags: { canonical: book.hiveBookAtUri },
+    });
     endTime(c, "render_book_page");
     endTime(c, "route_get_book");
     return res;

--- a/src/routes/main.tsx
+++ b/src/routes/main.tsx
@@ -12,6 +12,7 @@ import { BookFields } from "../db";
 import { createContextMiddleware } from "../context";
 import { loginRouter } from "../auth/router";
 import { Layout } from "../pages/layout";
+import { type AtTagsProps } from "../pages/components/AtTags";
 import { Navbar } from "../pages/navbar";
 import { Sidebar } from "../pages/sidebar";
 import { getProfile, getProfiles } from "../utils/getProfile";
@@ -53,7 +54,15 @@ declare module "hono" {
   interface ContextRenderer {
     (
       content: string | Promise<string>,
-      props: { title?: string; image?: string; description?: string },
+      props: {
+        title?: string;
+        image?: string;
+        description?: string;
+        url?: string;
+        ogType?: string;
+        ogExtra?: unknown;
+        atTags?: AtTagsProps;
+      },
     ): Response;
   }
 }

--- a/src/routes/pages.tsx
+++ b/src/routes/pages.tsx
@@ -9,6 +9,7 @@ import { z } from "zod";
 import { zValidator } from "@hono/zod-validator";
 
 import type { AppEnv } from "../context";
+import { BOOKHIVE_DID } from "../constants";
 import { BookFields } from "../db";
 import { Error as ErrorPage } from "../pages/error";
 import { Home } from "../pages/home";
@@ -106,7 +107,7 @@ const app = new Hono<AppEnv>()
   })
   .get("/.well-known/atproto-did", (c) => {
     c.header("Cache-Control", "public, max-age=86400, stale-while-revalidate=3600");
-    return c.text("did:plc:enu2j5xjlqsjaylv3du4myh4");
+    return c.text(BOOKHIVE_DID);
   })
   .get("/app", (c) => {
     c.header("Cache-Control", "public, max-age=86400, stale-while-revalidate=3600");

--- a/src/routes/profile.tsx
+++ b/src/routes/profile.tsx
@@ -450,6 +450,7 @@ const app = new Hono<AppEnv>()
         title: "BookHive | @" + handle,
         description: `@${handle}'s reading profile — ${parsedBooks.length} books read on BookHive`,
         image: `${new URL(c.req.url).origin}/og/profile/${handle}`,
+        atTags: { author: did },
       },
     );
   });

--- a/src/routes/shelves.tsx
+++ b/src/routes/shelves.tsx
@@ -268,6 +268,7 @@ const app = new Hono<AppEnv>()
         title: `BookHive | ${result.list.name}`,
         description:
           result.list.description || `${result.list.name} — a book shelf by @${handle} on BookHive`,
+        atTags: { canonical: result.list.uri, author: result.list.userDid },
       },
     );
   })


### PR DESCRIPTION
Implements the [AT Tags proposal](https://tangled.org/chrisshank.com/at-tags/): pages now declare which ATProto records/identities they correspond to via `<meta name="at:...">` tags, enabling rich link embeds, bidirectional verification, and richer search across the ecosystem. Adds a reusable `AtTags` helper (canonical/alternate/author/me + custom namespaced props, with array semantics, dedup, and DID→`at://` normalization), makes `Layout` emit a site-wide `at:me` plus a typed `atTags` prop, and sets per-page tags for book (`at:canonical`→catalog record), profile (`at:author`→DID), and shelf (`at:canonical`→list record, `at:author`→owner). The BookHive DID is promoted to a shared `BOOKHIVE_DID` constant, and the `ContextRenderer` type was widened (dropping an `as any` cast). Tags are built with hono's `html` template rather than JSX `<meta>` elements because hono/jsx dedupes head meta tags by `name`, which would otherwise collapse the proposal's array semantics. Verified via 8 new unit tests (full suite 222 pass), a clean typecheck, and live HTTP checks confirming the tags render on real pages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added AT Protocol metadata to book, profile, and shelf pages.
  - Pages now expose canonical links and author identity information through standard metadata.
  - Added site-wide identity metadata and a consistent service identity endpoint.
  - Improved support for alternate, custom, and repeated metadata values while filtering empty entries.

- **Documentation**
  - Documented the new metadata behavior and the pages that currently provide it.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->