### PR TITLE
feat: add Libby availability checking and OpenLibrary integration

### DIFF
--- a/src/client/components/LibbyBadge.tsx
+++ b/src/client/components/LibbyBadge.tsx
@@ -1,0 +1,124 @@
+import { useEffect, useState, type FC } from "hono/jsx/dom";
+
+import {
+  buildLibbyTitleUrl,
+  findBookInLibrary,
+  getLibraryPreferredKey,
+  type BookAvailability,
+} from "../utils/libbyApi";
+import {
+  getCachedAvailability,
+  getSelectedLibraries,
+  setCachedAvailability,
+} from "../utils/libbyStorage";
+
+export type LibbyBadgeProps = {
+  hiveId: string;
+  title: string;
+  author: string;
+  isbn: string | null;
+  isbn13: string | null;
+};
+
+type State =
+  | { kind: "no-library" }
+  | { kind: "checking" }
+  | { kind: "result"; data: BookAvailability; libraryKey: string }
+  | { kind: "error" };
+
+/**
+ * Compact "available now" pill that hydrates next to a want-to-read row.
+ * Reads the user's selected library out of `localStorage` (set on /libby);
+ * if none is configured the badge stays invisible to avoid noise on the
+ * profile shelf for users who haven't opted in.
+ */
+export const LibbyBadge: FC<LibbyBadgeProps> = ({ hiveId, title, author, isbn, isbn13 }) => {
+  const [state, setState] = useState<State>({ kind: "no-library" });
+
+  useEffect(() => {
+    const libs = getSelectedLibraries();
+    const active = libs[0];
+    if (!active) {
+      setState({ kind: "no-library" });
+      return;
+    }
+
+    let cancelled = false;
+    void (async () => {
+      let libraryKey = active.preferredKey;
+      try {
+        if (!libraryKey) {
+          libraryKey = await getLibraryPreferredKey(active.fulfillmentId);
+        }
+      } catch {
+        libraryKey = active.fulfillmentId;
+      }
+      if (cancelled) return;
+
+      const cached = getCachedAvailability(libraryKey, hiveId);
+      if (cached) {
+        setState({ kind: "result", data: cached, libraryKey });
+        return;
+      }
+
+      setState({ kind: "checking" });
+      try {
+        const data = await findBookInLibrary(libraryKey, title, author, {
+          primaryIsbn: isbn13 || isbn,
+        });
+        if (cancelled) return;
+        setCachedAvailability(libraryKey, hiveId, data);
+        setState({ kind: "result", data, libraryKey });
+      } catch {
+        if (cancelled) return;
+        setState({ kind: "error" });
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [hiveId, title, author, isbn, isbn13]);
+
+  if (state.kind === "no-library") return null;
+  if (state.kind === "checking") {
+    return <span class="text-xs text-muted-foreground">Checking Libby…</span>;
+  }
+  if (state.kind === "error") return null;
+
+  const top = state.data.results[0];
+  if (!top) return null;
+
+  const a = top.availability;
+  const url = buildLibbyTitleUrl(top.libraryKey, top.mediaItem.id);
+
+  if (a.copiesAvailable > 0) {
+    return (
+      <a
+        href={url}
+        target="_blank"
+        rel="noopener noreferrer"
+        class="inline-flex items-center gap-1 rounded-full bg-emerald-500/10 px-2 py-0.5 text-xs font-medium text-emerald-700 hover:bg-emerald-500/20 dark:text-emerald-300"
+        title={`Available now at ${state.libraryKey}`}
+      >
+        Libby · available
+      </a>
+    );
+  }
+
+  if (a.copiesOwned > 0) {
+    return (
+      <a
+        href={url}
+        target="_blank"
+        rel="noopener noreferrer"
+        class="inline-flex items-center gap-1 rounded-full bg-amber-500/10 px-2 py-0.5 text-xs font-medium text-amber-700 hover:bg-amber-500/20 dark:text-amber-300"
+        title={`${a.numberOfHolds} holds at ${state.libraryKey}`}
+      >
+        Libby · {a.numberOfHolds} hold{a.numberOfHolds === 1 ? "" : "s"}
+      </a>
+    );
+  }
+
+  return null;
+};

--- a/src/client/components/LibbyShelf.tsx
+++ b/src/client/components/LibbyShelf.tsx
@@ -1,0 +1,402 @@
+import { useEffect, useMemo, useRef, useState, type FC } from "hono/jsx/dom";
+
+import {
+  buildLibbyTitleUrl,
+  findBookInLibrary,
+  getLibraryPreferredKey,
+  searchLibraryByName,
+  type BookAvailability,
+  type LibbyLibrary,
+} from "../utils/libbyApi";
+import {
+  addLibrary as addLibraryToStorage,
+  getCachedAvailability,
+  getSelectedLibraries,
+  removeLibrary,
+  setCachedAvailability,
+} from "../utils/libbyStorage";
+import { useDebounce } from "./utils/useDebounce";
+
+export type LibbyShelfBook = {
+  hiveId: string;
+  title: string;
+  author: string;
+  cover: string | null;
+  isbn: string | null;
+  isbn13: string | null;
+  olWorkId: string | null;
+};
+
+type RowState =
+  | { kind: "idle" }
+  | { kind: "checking" }
+  | { kind: "result"; data: BookAvailability }
+  | { kind: "error"; message: string };
+
+const CONCURRENT_LOOKUPS = 4;
+
+export const LibbyShelf: FC<{ books: LibbyShelfBook[] }> = ({ books }) => {
+  const [libraries, setLibraries] = useState<LibbyLibrary[]>(() => getSelectedLibraries());
+  const [activeLibraryId, setActiveLibraryId] = useState<number | null>(
+    () => getSelectedLibraries()[0]?.id ?? null,
+  );
+  const [resolvedKeys, setResolvedKeys] = useState<Record<number, string>>({});
+  const [rowState, setRowState] = useState<Record<string, RowState>>({});
+  const lookupRef = useRef<{ running: number; queue: Array<() => Promise<void>> }>({
+    running: 0,
+    queue: [],
+  });
+
+  const activeLibrary = useMemo(
+    () => libraries.find((l) => l.id === activeLibraryId) ?? null,
+    [libraries, activeLibraryId],
+  );
+  const activeKey = activeLibrary
+    ? (resolvedKeys[activeLibrary.id] ?? activeLibrary.preferredKey ?? null)
+    : null;
+
+  // Resolve preferredKey for any selected library that doesn't already have one.
+  useEffect(() => {
+    let cancelled = false;
+    for (const lib of libraries) {
+      if (resolvedKeys[lib.id] || lib.preferredKey) continue;
+      void getLibraryPreferredKey(lib.fulfillmentId)
+        .then((key) => {
+          if (cancelled) return;
+          setResolvedKeys((prev) => ({ ...prev, [lib.id]: key }));
+        })
+        .catch(() => {
+          if (cancelled) return;
+          setResolvedKeys((prev) => ({ ...prev, [lib.id]: lib.fulfillmentId }));
+        });
+    }
+    return () => {
+      cancelled = true;
+    };
+  }, [libraries, resolvedKeys]);
+
+  // Hydrate cached availability whenever the active library changes.
+  useEffect(() => {
+    if (!activeKey) {
+      setRowState({});
+      return;
+    }
+    const next: Record<string, RowState> = {};
+    for (const book of books) {
+      const cached = getCachedAvailability(activeKey, book.hiveId);
+      next[book.hiveId] = cached ? { kind: "result", data: cached } : { kind: "idle" };
+    }
+    setRowState(next);
+  }, [activeKey, books]);
+
+  function runQueue() {
+    const lookup = lookupRef.current;
+    if (!lookup) return;
+    while (lookup.running < CONCURRENT_LOOKUPS && lookup.queue.length > 0) {
+      const next = lookup.queue.shift();
+      if (!next) break;
+      lookup.running += 1;
+      void next().finally(() => {
+        lookup.running -= 1;
+        runQueue();
+      });
+    }
+  }
+
+  function lookupOne(libraryKey: string, book: LibbyShelfBook) {
+    setRowState((prev) => ({ ...prev, [book.hiveId]: { kind: "checking" } }));
+    const lookup = lookupRef.current;
+    if (!lookup) return;
+    lookup.queue.push(async () => {
+      try {
+        const result = await findBookInLibrary(libraryKey, book.title, book.author, {
+          primaryIsbn: book.isbn13 || book.isbn,
+        });
+        setCachedAvailability(libraryKey, book.hiveId, result);
+        setRowState((prev) => ({ ...prev, [book.hiveId]: { kind: "result", data: result } }));
+      } catch (err) {
+        setRowState((prev) => ({
+          ...prev,
+          [book.hiveId]: {
+            kind: "error",
+            message: err instanceof Error ? err.message : "lookup failed",
+          },
+        }));
+      }
+    });
+    runQueue();
+  }
+
+  function checkAll() {
+    if (!activeKey) return;
+    for (const book of books) {
+      const state = rowState[book.hiveId];
+      if (!state || state.kind === "idle" || state.kind === "error") {
+        lookupOne(activeKey, book);
+      }
+    }
+  }
+
+  const onLibraryAdded = (lib: LibbyLibrary) => {
+    addLibraryToStorage(lib);
+    setLibraries(getSelectedLibraries());
+    setActiveLibraryId(lib.id);
+  };
+
+  const onLibraryRemoved = (id: number) => {
+    removeLibrary(id);
+    const next = getSelectedLibraries();
+    setLibraries(next);
+    if (activeLibraryId === id) {
+      setActiveLibraryId(next[0]?.id ?? null);
+    }
+  };
+
+  return (
+    <div class="space-y-6">
+      <LibraryPicker
+        libraries={libraries}
+        activeLibraryId={activeLibraryId}
+        onSelectLibrary={setActiveLibraryId}
+        onAddLibrary={onLibraryAdded}
+        onRemoveLibrary={onLibraryRemoved}
+      />
+
+      {activeLibrary && (
+        <div class="flex items-center justify-between gap-4">
+          <p class="text-sm text-muted-foreground">
+            Checking <span class="font-medium text-foreground">{activeLibrary.name}</span>
+          </p>
+          <button
+            type="button"
+            class="rounded-md bg-primary px-3 py-1.5 text-sm font-medium text-primary-foreground hover:bg-primary/90 disabled:opacity-50"
+            onClick={checkAll}
+            disabled={!activeKey}
+          >
+            Check all books
+          </button>
+        </div>
+      )}
+
+      <ul class="divide-y divide-border">
+        {books.map((book) => (
+          <li key={book.hiveId} class="flex items-start gap-3 py-3">
+            <div class="h-16 w-12 shrink-0 overflow-hidden rounded-sm bg-muted shadow-sm">
+              {book.cover ? (
+                <img src={book.cover} alt="" class="h-full w-full object-cover" />
+              ) : null}
+            </div>
+            <div class="min-w-0 flex-1">
+              <a
+                href={`/books/${book.hiveId}`}
+                class="line-clamp-1 text-sm font-medium text-foreground hover:underline"
+              >
+                {book.title}
+              </a>
+              <p class="line-clamp-1 text-xs text-muted-foreground">{book.author}</p>
+              <div class="mt-2">
+                <BadgeForState
+                  state={rowState[book.hiveId] ?? { kind: "idle" }}
+                  libraryReady={Boolean(activeKey)}
+                  onCheck={() => activeKey && lookupOne(activeKey, book)}
+                />
+              </div>
+            </div>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+};
+
+const LibraryPicker: FC<{
+  libraries: LibbyLibrary[];
+  activeLibraryId: number | null;
+  onSelectLibrary: (id: number) => void;
+  onAddLibrary: (lib: LibbyLibrary) => void;
+  onRemoveLibrary: (id: number) => void;
+}> = ({ libraries, activeLibraryId, onSelectLibrary, onAddLibrary, onRemoveLibrary }) => {
+  const [query, setQuery] = useState("");
+  const [results, setResults] = useState<LibbyLibrary[]>([]);
+  const [searching, setSearching] = useState(false);
+  const debounced = useDebounce(query, 250);
+
+  useEffect(() => {
+    if (debounced.length < 2) {
+      setResults([]);
+      return;
+    }
+    let cancelled = false;
+    setSearching(true);
+    void searchLibraryByName(debounced)
+      .then((libs) => {
+        if (cancelled) return;
+        setResults(libs.slice(0, 20));
+      })
+      .catch(() => {
+        if (cancelled) return;
+        setResults([]);
+      })
+      .finally(() => {
+        if (!cancelled) setSearching(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [debounced]);
+
+  return (
+    <div class="space-y-3">
+      <label class="block text-sm font-medium text-foreground">Your library</label>
+
+      {libraries.length > 0 && (
+        <div class="flex flex-wrap gap-2">
+          {libraries.map((lib) => (
+            <button
+              key={lib.id}
+              type="button"
+              class={`rounded-full border px-3 py-1 text-xs ${
+                lib.id === activeLibraryId
+                  ? "border-primary bg-primary text-primary-foreground"
+                  : "border-border bg-card text-foreground hover:bg-muted"
+              }`}
+              onClick={() => onSelectLibrary(lib.id)}
+            >
+              {lib.name}
+              <span
+                role="button"
+                aria-label={`Remove ${lib.name}`}
+                class="ml-2 opacity-70 hover:opacity-100"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  onRemoveLibrary(lib.id);
+                }}
+              >
+                ×
+              </span>
+            </button>
+          ))}
+        </div>
+      )}
+
+      <input
+        type="text"
+        value={query}
+        onInput={(e) => setQuery((e.currentTarget as HTMLInputElement).value)}
+        placeholder="Search for a library — try your city or system name"
+        class="w-full rounded-md border border-input bg-background px-3 py-2 text-sm focus:border-primary focus:outline-none"
+      />
+
+      {results.length > 0 && (
+        <ul class="max-h-72 divide-y divide-border overflow-y-auto rounded-md border border-border bg-card">
+          {results.map((lib) => (
+            <li key={lib.id}>
+              <button
+                type="button"
+                class="flex w-full items-center justify-between px-3 py-2 text-left text-sm hover:bg-muted"
+                onClick={() => {
+                  onAddLibrary(lib);
+                  setQuery("");
+                  setResults([]);
+                }}
+              >
+                <span class="text-foreground">{lib.name}</span>
+                {lib.type ? <span class="text-xs text-muted-foreground">{lib.type}</span> : null}
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+
+      {searching && results.length === 0 && (
+        <p class="text-xs text-muted-foreground">Searching libraries…</p>
+      )}
+    </div>
+  );
+};
+
+const BadgeForState: FC<{
+  state: RowState;
+  libraryReady: boolean;
+  onCheck: () => void;
+}> = ({ state, libraryReady, onCheck }) => {
+  if (!libraryReady) {
+    return <span class="text-xs text-muted-foreground">Pick a library to check.</span>;
+  }
+  if (state.kind === "idle") {
+    return (
+      <button
+        type="button"
+        class="rounded-md border border-border px-2 py-0.5 text-xs text-muted-foreground hover:bg-muted"
+        onClick={onCheck}
+      >
+        Check Libby
+      </button>
+    );
+  }
+  if (state.kind === "checking") {
+    return <span class="text-xs text-muted-foreground">Checking…</span>;
+  }
+  if (state.kind === "error") {
+    return (
+      <button
+        type="button"
+        class="rounded-md border border-border px-2 py-0.5 text-xs text-muted-foreground hover:bg-muted"
+        onClick={onCheck}
+        title={state.message}
+      >
+        Try again
+      </button>
+    );
+  }
+
+  const top = state.data.results[0];
+  if (!top) {
+    return <span class="text-xs text-muted-foreground">Not at this library.</span>;
+  }
+
+  const a = top.availability;
+  const url = buildLibbyTitleUrl(top.libraryKey, top.mediaItem.id);
+
+  if (a.copiesAvailable > 0) {
+    return (
+      <a
+        href={url}
+        target="_blank"
+        rel="noopener noreferrer"
+        class="inline-flex items-center gap-1 rounded-full bg-emerald-500/10 px-2 py-0.5 text-xs font-medium text-emerald-700 hover:bg-emerald-500/20 dark:text-emerald-300"
+      >
+        Available now · {a.copiesAvailable} copies
+      </a>
+    );
+  }
+
+  if (a.copiesOwned > 0) {
+    const wait =
+      a.estimatedWaitDays != null && a.estimatedWaitDays > 0
+        ? `, ~${a.estimatedWaitDays}d wait`
+        : "";
+    return (
+      <a
+        href={url}
+        target="_blank"
+        rel="noopener noreferrer"
+        class="inline-flex items-center gap-1 rounded-full bg-amber-500/10 px-2 py-0.5 text-xs font-medium text-amber-700 hover:bg-amber-500/20 dark:text-amber-300"
+      >
+        {a.numberOfHolds} hold{a.numberOfHolds === 1 ? "" : "s"}
+        {wait}
+      </a>
+    );
+  }
+
+  return (
+    <a
+      href={url}
+      target="_blank"
+      rel="noopener noreferrer"
+      class="inline-flex items-center gap-1 rounded-full bg-muted px-2 py-0.5 text-xs text-muted-foreground hover:bg-muted/80"
+    >
+      Listed but unavailable
+    </a>
+  );
+};

--- a/src/client/components/LibraryTable.tsx
+++ b/src/client/components/LibraryTable.tsx
@@ -9,6 +9,7 @@ import {
   updateBook,
   deleteBook,
 } from "./bookActions";
+import { LibbyBadge } from "./LibbyBadge";
 
 type LibraryBook = {
   hiveId: string;
@@ -23,9 +24,23 @@ type LibraryBook = {
   createdAt: string;
   owned: number;
   review: string | null;
+  isbn?: string | null;
+  isbn13?: string | null;
 };
 
 const FINISHED = "buzz.bookhive.defs#finished";
+const WANTTOREAD = "buzz.bookhive.defs#wantToRead";
+
+const renderLibbyBadge = (book: LibraryBook) =>
+  book.status === WANTTOREAD ? (
+    <LibbyBadge
+      hiveId={book.hiveId}
+      title={book.title}
+      author={book.authors.split("\t").join(", ")}
+      isbn={book.isbn ?? null}
+      isbn13={book.isbn13 ?? null}
+    />
+  ) : null;
 
 // --- Desktop row ---
 
@@ -50,6 +65,9 @@ const TableRow: FC<{
           <p className="line-clamp-1 text-xs text-muted-foreground">
             {book.authors.split("\t").join(", ")}
           </p>
+          <div className="mt-1" onClick={(e) => e.stopPropagation()}>
+            {renderLibbyBadge(book)}
+          </div>
         </div>
       </div>
     </td>
@@ -153,6 +171,7 @@ const MobileCard: FC<{
           {book.status && (
             <div className="mt-1 flex flex-wrap items-center gap-2">
               <span className="badge capitalize">{STATUS_LABELS[book.status] || book.status}</span>
+              {renderLibbyBadge(book)}
             </div>
           )}
         </div>

--- a/src/client/index.tsx
+++ b/src/client/index.tsx
@@ -3,6 +3,7 @@ import "basecoat-css/sidebar";
 import "../index.css";
 
 import { SearchTrigger } from "./components/SearchBox";
+import type { LibbyShelfBook } from "./components/LibbyShelf";
 
 document.addEventListener("DOMContentLoaded", () => {
   // Shared open function: the SearchPalette registers it once lazily loaded,
@@ -95,6 +96,14 @@ document.addEventListener("DOMContentLoaded", () => {
     const books = JSON.parse(libraryTable.dataset["books"] || "[]");
     void import("./components/LibraryTable").then(({ LibraryTable }) => {
       render(<LibraryTable initialBooks={books} />, libraryTable);
+    });
+  }
+
+  const libbyShelf = document.getElementById("mount-libby-shelf");
+  if (libbyShelf) {
+    const books = JSON.parse(libbyShelf.dataset["books"] || "[]") as LibbyShelfBook[];
+    void import("./components/LibbyShelf").then(({ LibbyShelf }) => {
+      render(<LibbyShelf books={books} />, libbyShelf);
     });
   }
 

--- a/src/client/utils/libbyApi.ts
+++ b/src/client/utils/libbyApi.ts
@@ -1,0 +1,299 @@
+/**
+ * Browser-only Libby/OverDrive Thunder API client. Adapted from the
+ * MIT-licensed shelfcheck project (`nowells/libby-reading-list`,
+ * `app/lib/libby.ts`). Drops the per-book live-availability refresh
+ * (search-embedded availability is what we surface in v1) and the
+ * Open Library alternate-edition ISBN fan-out (we already resolve
+ * workIds server-side via `src/utils/openLibrary.ts`).
+ */
+import {
+  contentWordsMatch as sharedContentWordsMatch,
+  similarityScore as sharedSimilarityScore,
+} from "../../utils/bookMatching";
+
+const THUNDER_API_URL = "https://thunder.api.overdrive.com/v2";
+const LOCATE_API_URL = "https://locate.libbyapp.com/autocomplete";
+
+export const REFERENCE_LIBRARY = "lapl";
+
+export type LibbyLibrary = {
+  id: number;
+  name: string;
+  fulfillmentId: string;
+  preferredKey?: string;
+  type?: string;
+  isConsortium?: boolean;
+  logoUrl?: string;
+};
+
+export type LibbyMediaItem = {
+  id: string;
+  title: string;
+  sortTitle?: string;
+  subtitle?: string;
+  type?: { id: string; name: string };
+  formats?: Array<{ id: string; name: string; duration?: string }>;
+  creators?: Array<{ name: string; role: string }>;
+  covers?: { cover150Wide?: { href: string } };
+  series?: string;
+  detailedSeries?: { seriesName: string; readingOrder: string };
+  firstCreatorSortName?: string;
+  publisher?: { id: string; name: string };
+  publishDate?: string;
+  isAvailable?: boolean;
+  ownedCopies?: number;
+  availableCopies?: number;
+  holdsCount?: number;
+  estimatedWaitDays?: number;
+};
+
+export type AvailabilityInfo = {
+  id: string;
+  copiesOwned: number;
+  copiesAvailable: number;
+  numberOfHolds: number;
+  isAvailable: boolean;
+  estimatedWaitDays?: number;
+};
+
+export type BookAvailabilityResult = {
+  mediaItem: LibbyMediaItem;
+  availability: AvailabilityInfo;
+  matchScore: number;
+  formatType: string;
+  libraryKey: string;
+};
+
+export type BookAvailability = {
+  bookTitle: string;
+  bookAuthor: string;
+  coverUrl?: string;
+  seriesInfo?: { seriesName: string; readingOrder: string };
+  results: BookAvailabilityResult[];
+};
+
+const inflight = new Map<string, Promise<unknown>>();
+
+async function thunderFetch<T>(path: string): Promise<T> {
+  const url = `${THUNDER_API_URL}${path}`;
+  const existing = inflight.get(url);
+  if (existing) return existing as Promise<T>;
+
+  const promise = (async () => {
+    const res = await fetch(url, { headers: { "x-client-id": "dewey" } });
+    if (!res.ok) {
+      throw new Error(`Libby API error: ${res.status} ${res.statusText}`);
+    }
+    return (await res.json()) as T;
+  })().finally(() => {
+    inflight.delete(url);
+  });
+
+  inflight.set(url, promise);
+  return promise;
+}
+
+export async function searchLibrary(
+  libraryKey: string,
+  query: string,
+  format?: "ebook" | "audiobook",
+): Promise<LibbyMediaItem[]> {
+  const params = new URLSearchParams({ query });
+  if (format === "ebook") {
+    params.set(
+      "format",
+      "ebook-kindle,ebook-overdrive,ebook-epub-adobe,ebook-epub-open,ebook-media-do",
+    );
+  } else if (format === "audiobook") {
+    params.set("format", "audiobook-overdrive,audiobook-mp3");
+  }
+  const data = await thunderFetch<{ items?: LibbyMediaItem[] }>(
+    `/libraries/${libraryKey}/media?${params.toString()}`,
+  );
+  return data.items ?? [];
+}
+
+async function getMediaItem(libraryKey: string, titleId: string): Promise<LibbyMediaItem | null> {
+  try {
+    return await thunderFetch<LibbyMediaItem>(`/libraries/${libraryKey}/media/${titleId}`);
+  } catch {
+    return null;
+  }
+}
+
+export async function searchLibraryByName(query: string): Promise<LibbyLibrary[]> {
+  const url = `${LOCATE_API_URL}/${encodeURIComponent(query)}`;
+  const res = await fetch(url);
+  if (!res.ok) throw new Error(`Libby locate API error: ${res.status}`);
+  const data = (await res.json()) as {
+    branches?: Array<{
+      systems?: Array<{
+        id: number;
+        name: string;
+        fulfillmentId: string;
+        type?: string;
+        isConsortium?: boolean;
+        styling?: { logos?: Array<{ sourceUrl?: string }> };
+      }>;
+    }>;
+  };
+
+  const seen = new Set<number>();
+  const libraries: LibbyLibrary[] = [];
+  for (const branch of data.branches ?? []) {
+    for (const system of branch.systems ?? []) {
+      if (seen.has(system.id)) continue;
+      seen.add(system.id);
+      libraries.push({
+        id: system.id,
+        name: system.name,
+        fulfillmentId: system.fulfillmentId,
+        type: system.type,
+        isConsortium: system.isConsortium,
+        logoUrl: system.styling?.logos?.[0]?.sourceUrl,
+      });
+    }
+  }
+  return libraries;
+}
+
+export async function getLibraryPreferredKey(fulfillmentId: string): Promise<string> {
+  const data = await thunderFetch<{ preferredKey?: string }>(`/libraries/${fulfillmentId}`);
+  return data.preferredKey ?? fulfillmentId;
+}
+
+function availabilityFor(item: LibbyMediaItem): AvailabilityInfo {
+  return {
+    id: item.id,
+    copiesOwned: item.ownedCopies ?? 0,
+    copiesAvailable: item.availableCopies ?? 0,
+    numberOfHolds: item.holdsCount ?? 0,
+    isAvailable: item.isAvailable ?? (item.availableCopies ?? 0) > 0,
+    estimatedWaitDays: item.estimatedWaitDays,
+  };
+}
+
+function buildResult(
+  libraryKey: string,
+  item: LibbyMediaItem,
+  matchScore: number,
+): BookAvailabilityResult {
+  return {
+    mediaItem: item,
+    availability: availabilityFor(item),
+    matchScore,
+    formatType: item.type?.id ?? "unknown",
+    libraryKey,
+  };
+}
+
+export type FindBookOptions = {
+  primaryIsbn?: string | null;
+};
+
+export async function findBookInLibrary(
+  libraryKey: string,
+  title: string,
+  author: string,
+  options: FindBookOptions = {},
+): Promise<BookAvailability> {
+  const result: BookAvailability = {
+    bookTitle: title,
+    bookAuthor: author,
+    results: [],
+  };
+  const seenIds = new Set<string>();
+
+  async function tryIsbn(isbn: string) {
+    try {
+      const items = await searchLibrary(libraryKey, isbn);
+      for (const item of items.slice(0, 3)) {
+        if (seenIds.has(item.id)) continue;
+        seenIds.add(item.id);
+        result.results.push(buildResult(libraryKey, item, 1));
+      }
+    } catch {
+      /* fall through */
+    }
+  }
+
+  // Phase 1: precise ISBN search.
+  if (options.primaryIsbn) {
+    await tryIsbn(options.primaryIsbn);
+  }
+
+  // Phase 2: text search fallback gated by contentWordsMatch.
+  if (result.results.length === 0) {
+    const queries = [
+      `${author} ${title}`,
+      title.includes(":") ? `${author} ${(title.split(":")[0] ?? title).trim()}` : null,
+      title,
+    ].filter(Boolean) as string[];
+
+    for (const query of queries) {
+      try {
+        const items = await searchLibrary(libraryKey, query);
+        for (const item of items.slice(0, 5)) {
+          if (seenIds.has(item.id)) continue;
+          const titleScore = sharedSimilarityScore(title, item.title);
+          const authorName = item.creators?.find((c) => c.role === "Author")?.name ?? "";
+          const authorScore = author ? sharedSimilarityScore(author, authorName) : 0.5;
+          if (
+            titleScore >= 0.4 &&
+            authorScore >= 0.3 &&
+            sharedContentWordsMatch(title, item.title)
+          ) {
+            seenIds.add(item.id);
+            result.results.push(buildResult(libraryKey, item, (titleScore + authorScore) / 2));
+          }
+        }
+      } catch {
+        /* try next */
+      }
+      if (result.results.length > 0) break;
+    }
+  }
+
+  // Phase 3: reference-library deep search → look up canonical title id
+  // in a large library, then fetch that id from the user's library.
+  if (result.results.length === 0 && libraryKey !== REFERENCE_LIBRARY) {
+    try {
+      const refItems = await searchLibrary(REFERENCE_LIBRARY, `${author} ${title}`);
+      for (const item of refItems.slice(0, 5)) {
+        if (seenIds.has(item.id)) continue;
+        const titleScore = sharedSimilarityScore(title, item.title);
+        const authorName = item.creators?.find((c) => c.role === "Author")?.name ?? "";
+        const authorScore = author ? sharedSimilarityScore(author, authorName) : 0.5;
+        if (titleScore >= 0.4 && authorScore >= 0.3 && sharedContentWordsMatch(title, item.title)) {
+          seenIds.add(item.id);
+          const localItem = await getMediaItem(libraryKey, item.id);
+          if (!localItem) continue;
+          result.results.push(buildResult(libraryKey, localItem, (titleScore + authorScore) / 2));
+        }
+      }
+    } catch {
+      /* deep search failed */
+    }
+  }
+
+  result.results.sort((a, b) => b.matchScore - a.matchScore);
+
+  for (const r of result.results) {
+    const href = r.mediaItem.covers?.cover150Wide?.href;
+    if (href && !result.coverUrl) result.coverUrl = href;
+    const ds = r.mediaItem.detailedSeries;
+    if (ds && !result.seriesInfo) result.seriesInfo = { ...ds };
+    if (result.coverUrl && result.seriesInfo) break;
+  }
+
+  return result;
+}
+
+/**
+ * Build the Libby app URL for a specific title. Mirrors the format the
+ * Libby web app uses; opening this in a new tab lands the user on the
+ * borrow page for that title in the named library.
+ */
+export function buildLibbyTitleUrl(libraryKey: string, titleId: string): string {
+  return `https://libbyapp.com/library/${libraryKey}/page-1/${titleId}`;
+}

--- a/src/client/utils/libbyStorage.ts
+++ b/src/client/utils/libbyStorage.ts
@@ -1,0 +1,73 @@
+import type { BookAvailability, LibbyLibrary } from "./libbyApi";
+
+const SCHEMA = 1;
+const LIBRARIES_KEY = `bookhive:libby:v${SCHEMA}:libraries`;
+const RESULTS_KEY = (libraryKey: string, hiveId: string) =>
+  `bookhive:libby:v${SCHEMA}:result:${libraryKey}:${hiveId}`;
+const RESULTS_TTL_MS = 60 * 60 * 1000;
+
+type StoredResult = { v: BookAvailability; t: number };
+
+function safeGet<T>(key: string): T | null {
+  try {
+    const raw = localStorage.getItem(key);
+    if (!raw) return null;
+    return JSON.parse(raw) as T;
+  } catch {
+    return null;
+  }
+}
+
+function safeSet(key: string, value: unknown) {
+  try {
+    localStorage.setItem(key, JSON.stringify(value));
+  } catch {
+    /* quota or private mode — non-fatal */
+  }
+}
+
+export function getSelectedLibraries(): LibbyLibrary[] {
+  return safeGet<LibbyLibrary[]>(LIBRARIES_KEY) ?? [];
+}
+
+export function setSelectedLibraries(libraries: LibbyLibrary[]) {
+  safeSet(LIBRARIES_KEY, libraries);
+}
+
+export function addLibrary(library: LibbyLibrary) {
+  const current = getSelectedLibraries();
+  if (current.some((l) => l.id === library.id)) return;
+  setSelectedLibraries([...current, library]);
+}
+
+export function removeLibrary(libraryId: number) {
+  setSelectedLibraries(getSelectedLibraries().filter((l) => l.id !== libraryId));
+}
+
+export function getCachedAvailability(libraryKey: string, hiveId: string): BookAvailability | null {
+  const stored = safeGet<StoredResult>(RESULTS_KEY(libraryKey, hiveId));
+  if (!stored) return null;
+  if (Date.now() - stored.t > RESULTS_TTL_MS) return null;
+  return stored.v;
+}
+
+export function setCachedAvailability(
+  libraryKey: string,
+  hiveId: string,
+  result: BookAvailability,
+) {
+  safeSet(RESULTS_KEY(libraryKey, hiveId), { v: result, t: Date.now() });
+}
+
+export function clearLibbyCache() {
+  try {
+    const toRemove: string[] = [];
+    for (let i = 0; i < localStorage.length; i++) {
+      const key = localStorage.key(i);
+      if (key && key.startsWith("bookhive:libby:")) toRemove.push(key);
+    }
+    for (const key of toRemove) localStorage.removeItem(key);
+  } catch {
+    /* non-fatal */
+  }
+}

--- a/src/db.ts
+++ b/src/db.ts
@@ -908,6 +908,21 @@ migrations["021"] = {
   },
 };
 
+migrations["022"] = {
+  async up(db: Kysely<unknown>) {
+    await db.schema.alterTable("book_id_map").addColumn("olWorkId", "text").execute();
+    await db.schema
+      .createIndex("idx_book_id_map_ol_work_id")
+      .on("book_id_map")
+      .column("olWorkId")
+      .execute();
+  },
+  async down(db: Kysely<unknown>) {
+    await db.schema.dropIndex("idx_book_id_map_ol_work_id").ifExists().execute();
+    await db.schema.alterTable("book_id_map").dropColumn("olWorkId").execute();
+  },
+};
+
 // APIs
 
 export const createDb = (location: string): { db: Database; sqlite: DatabaseSync } => {

--- a/src/pages/libby.tsx
+++ b/src/pages/libby.tsx
@@ -1,0 +1,44 @@
+import type { FC } from "hono/jsx";
+
+export type LibbyPageBook = {
+  hiveId: string;
+  title: string;
+  author: string;
+  cover: string | null;
+  isbn: string | null;
+  isbn13: string | null;
+  olWorkId: string | null;
+};
+
+export const LibbyPage: FC<{ books: LibbyPageBook[] }> = ({ books }) => {
+  return (
+    <div class="space-y-6 px-4 lg:px-8">
+      <header class="space-y-2">
+        <h1 class="text-3xl font-bold tracking-tight text-foreground">Libby availability</h1>
+        <p class="max-w-2xl text-sm text-muted-foreground">
+          Cross-check your want-to-read shelf against your local library on Libby. Pick a library
+          and we&apos;ll look up each book — borrow now if it&apos;s available, or place a hold. We
+          never store your library selection on our servers; it lives in your browser.
+        </p>
+      </header>
+
+      {books.length === 0 ? (
+        <div class="rounded-xl border border-border bg-card px-6 py-12 text-center">
+          <p class="text-lg font-medium text-foreground">No want-to-read books yet.</p>
+          <p class="mt-1 text-sm text-muted-foreground">
+            Add some books to your want-to-read shelf and they&apos;ll show up here.
+          </p>
+        </div>
+      ) : (
+        <div
+          id="mount-libby-shelf"
+          data-books={JSON.stringify(books)}
+          class="rounded-xl border border-border bg-card p-4"
+        >
+          {/* Hydrated by src/client/index.tsx → LibbyShelf. */}
+          <p class="text-sm text-muted-foreground">Loading Libby availability…</p>
+        </div>
+      )}
+    </div>
+  );
+};

--- a/src/pages/profile.tsx
+++ b/src/pages/profile.tsx
@@ -22,6 +22,7 @@ export const ProfilePage: FC<{
   followersProfiles?: ProfileViewDetailed[];
   genreStats?: { genre: string; count: number }[];
   userLists?: Array<BookListRow & { itemCount: number | null }>;
+  wantToReadIdentifiers?: Map<string, { isbn: string | null; isbn13: string | null }>;
 }> = ({
   handle,
   did,
@@ -37,6 +38,7 @@ export const ProfilePage: FC<{
   followersProfiles = [],
   genreStats = [],
   userLists = [],
+  wantToReadIdentifiers,
 }) => {
   const year = new Date().getFullYear();
   const booksThisYear = books.reduce((sum, b) => {
@@ -171,25 +173,44 @@ export const ProfilePage: FC<{
 
           {/* Library */}
           <section>
-            <h2 class="text-foreground mb-4 text-2xl font-bold tracking-tight">Library</h2>
+            <div class="mb-4 flex items-end justify-between gap-3">
+              <h2 class="text-foreground text-2xl font-bold tracking-tight">Library</h2>
+              {isOwnProfile && books.some((b) => b.status === BOOK_STATUS.WANTTOREAD) && (
+                <a
+                  href="/libby"
+                  class="text-primary hover:underline text-sm font-medium"
+                  title="Cross-check your want-to-read shelf with Libby"
+                >
+                  Check Libby availability →
+                </a>
+              )}
+            </div>
             {isOwnProfile ? (
               <div
                 id="mount-library-table"
                 data-books={JSON.stringify(
-                  books.map((b) => ({
-                    hiveId: b.hiveId,
-                    title: b.title,
-                    authors: b.authors,
-                    cover: b.cover,
-                    thumbnail: b.thumbnail,
-                    status: b.status,
-                    stars: b.stars,
-                    startedAt: b.startedAt,
-                    finishedAt: b.finishedAt,
-                    createdAt: b.createdAt,
-                    owned: b.owned,
-                    review: b.review,
-                  })),
+                  books.map((b) => {
+                    const ids =
+                      b.status === BOOK_STATUS.WANTTOREAD
+                        ? wantToReadIdentifiers?.get(b.hiveId)
+                        : undefined;
+                    return {
+                      hiveId: b.hiveId,
+                      title: b.title,
+                      authors: b.authors,
+                      cover: b.cover,
+                      thumbnail: b.thumbnail,
+                      status: b.status,
+                      stars: b.stars,
+                      startedAt: b.startedAt,
+                      finishedAt: b.finishedAt,
+                      createdAt: b.createdAt,
+                      owned: b.owned,
+                      review: b.review,
+                      isbn: ids?.isbn ?? null,
+                      isbn13: ids?.isbn13 ?? null,
+                    };
+                  }),
                 )}
               />
             ) : (

--- a/src/routes/libby.tsx
+++ b/src/routes/libby.tsx
@@ -1,0 +1,59 @@
+/**
+ * Libby availability route. Mounted at `/libby`.
+ *
+ * Loads the signed-in user's want-to-read shelf joined with `book_id_map`
+ * so the client-side island has every identifier (ISBN-10/13, OL workId)
+ * it needs to query Libby's Thunder API directly from the browser.
+ */
+import { Hono } from "hono";
+import { endTime, startTime } from "hono/timing";
+
+import type { AppEnv } from "../context";
+import { BOOK_STATUS } from "../constants";
+import { LibbyPage } from "../pages/libby";
+
+const app = new Hono<AppEnv>().get("/", async (c) => {
+  const ctx = c.get("ctx");
+  const agent = await ctx.getSessionAgent();
+  if (!agent) {
+    return c.redirect("/login?next=/libby");
+  }
+
+  startTime(c, "libby_books");
+  const rows = await ctx.db
+    .selectFrom("user_book")
+    .leftJoin("hive_book", "user_book.hiveId", "hive_book.id")
+    .leftJoin("book_id_map", "user_book.hiveId", "book_id_map.hiveId")
+    .select([
+      "user_book.hiveId",
+      "user_book.title",
+      "user_book.authors",
+      "hive_book.cover",
+      "hive_book.thumbnail",
+      "book_id_map.isbn",
+      "book_id_map.isbn13",
+      "book_id_map.olWorkId",
+    ])
+    .where("user_book.userDid", "=", agent.did)
+    .where("user_book.status", "=", BOOK_STATUS.WANTTOREAD)
+    .orderBy("user_book.indexedAt", "desc")
+    .execute();
+  endTime(c, "libby_books");
+
+  const books = rows.map((row) => ({
+    hiveId: row.hiveId,
+    title: row.title,
+    author: row.authors.split("\t").filter(Boolean).join(", "),
+    cover: row.cover ?? row.thumbnail ?? null,
+    isbn: row.isbn,
+    isbn13: row.isbn13,
+    olWorkId: row.olWorkId,
+  }));
+
+  return c.render(<LibbyPage books={books} />, {
+    title: "BookHive | Libby Availability",
+    description: "Check which of your want-to-read books are available now at your local library.",
+  });
+});
+
+export default app;

--- a/src/routes/main.tsx
+++ b/src/routes/main.tsx
@@ -52,6 +52,7 @@ import shelves from "./shelves";
 import library from "./library";
 import opds from "./opds";
 import kosync from "./sync/kosync";
+import libby from "./libby";
 
 declare module "hono" {
   interface ContextRenderer {
@@ -438,6 +439,7 @@ export function mainRouter(deps: AppDeps): HonoServer {
   app.route("/rss", rss);
   app.route("/og", og);
   app.route("/kosync", kosync);
+  app.route("/libby", libby);
 
   createXrpcRouter(app, {
     searchBooks,

--- a/src/routes/profile.tsx
+++ b/src/routes/profile.tsx
@@ -9,6 +9,7 @@ import { endTime, startTime } from "hono/timing";
 
 import { sql } from "kysely";
 import type { AppEnv } from "../context";
+import { BOOK_STATUS } from "../constants";
 import { BookFields } from "../db";
 import { Error as ErrorPage } from "../pages/error";
 import { ProfilePage } from "../pages/profile";
@@ -311,6 +312,30 @@ const app = new Hono<AppEnv>()
     const parsedBooks = books.map((book) => hydrateUserBook(book));
     endTime(c, "books+session");
 
+    // Pull ISBNs for the user's want-to-read shelf so the client-side
+    // Libby badge can run a precise availability lookup. Limit to that
+    // status to avoid a needless join across the whole library.
+    startTime(c, "wantToReadIdentifiers");
+    const wantToReadIds = parsedBooks
+      .filter((b) => b.status === BOOK_STATUS.WANTTOREAD)
+      .map((b) => b.hiveId);
+    const wantToReadIdentifiersMap = new Map<
+      string,
+      { isbn: string | null; isbn13: string | null }
+    >();
+    if (wantToReadIds.length > 0) {
+      const rows = await c
+        .get("ctx")
+        .db.selectFrom("book_id_map")
+        .select(["hiveId", "isbn", "isbn13"])
+        .where("hiveId", "in", wantToReadIds)
+        .execute();
+      for (const row of rows) {
+        wantToReadIdentifiersMap.set(row.hiveId, { isbn: row.isbn, isbn13: row.isbn13 });
+      }
+    }
+    endTime(c, "wantToReadIdentifiers");
+
     startTime(c, "isFollowing");
     const isFollowing =
       sessionAgent && sessionAgent.did !== did
@@ -445,6 +470,7 @@ const app = new Hono<AppEnv>()
         followersProfiles={followersProfiles}
         genreStats={genreStats}
         userLists={userLists}
+        wantToReadIdentifiers={wantToReadIdentifiersMap}
       />,
       {
         title: "BookHive | @" + handle,

--- a/src/types.ts
+++ b/src/types.ts
@@ -233,6 +233,7 @@ export type BookIdentifiersRow = {
   isbn: string | null;
   isbn13: string | null;
   goodreadsId: string | null;
+  olWorkId: string | null;
   updatedAt: string;
 };
 

--- a/src/utils/bookIdentifiers.ts
+++ b/src/utils/bookIdentifiers.ts
@@ -1,3 +1,4 @@
+import { sql } from "kysely";
 import type { Database } from "../db";
 import type { BookIdentifiers, BookIdentifiersRow, HiveBook, HiveId } from "../types";
 
@@ -91,8 +92,19 @@ function extractGoodreadsId(book: BookIdentifiersSource): string | null {
   return normalizeGoodreadsId(match[1]);
 }
 
+export function normalizeOlWorkId(value: string | null | undefined): string | null {
+  const normalized = normalizeString(value);
+  if (!normalized) {
+    return null;
+  }
+  // Accept "OL45883W" or a trailing path like "/works/OL45883W".
+  const match = normalized.match(/(OL[0-9]+W)\b/i);
+  return match?.[1] ? match[1].toUpperCase() : null;
+}
+
 export function deriveBookIdentifiers(
   book: BookIdentifiersSource,
+  overrides: { olWorkId?: string | null } = {},
 ): Omit<BookIdentifiersRow, "updatedAt"> {
   const meta = parseMeta(book.meta);
   return {
@@ -100,6 +112,7 @@ export function deriveBookIdentifiers(
     isbn: normalizeIsbn(typeof meta.isbn === "string" ? meta.isbn : null),
     isbn13: normalizeIsbn13(typeof meta.isbn13 === "string" ? meta.isbn13 : null),
     goodreadsId: extractGoodreadsId(book),
+    olWorkId: normalizeOlWorkId(overrides.olWorkId ?? null),
   };
 }
 
@@ -117,11 +130,16 @@ export function toBookIdentifiersOutput(
     isbn10: row.isbn ?? undefined,
     isbn13: row.isbn13 ?? undefined,
     goodreadsId: row.goodreadsId ?? undefined,
+    openLibraryId: row.olWorkId ?? undefined,
   };
 }
 
-export async function upsertBookIdentifiers(db: Database, book: BookIdentifiersSource) {
-  const identifiers = deriveBookIdentifiers(book);
+export async function upsertBookIdentifiers(
+  db: Database,
+  book: BookIdentifiersSource,
+  overrides: { olWorkId?: string | null } = {},
+) {
+  const identifiers = deriveBookIdentifiers(book, overrides);
   const updatedAt = new Date().toISOString();
 
   await db
@@ -131,6 +149,7 @@ export async function upsertBookIdentifiers(db: Database, book: BookIdentifiersS
       isbn: identifiers.isbn,
       isbn13: identifiers.isbn13,
       goodreadsId: identifiers.goodreadsId,
+      olWorkId: identifiers.olWorkId,
       updatedAt,
     })
     .onConflict((oc) =>
@@ -138,6 +157,10 @@ export async function upsertBookIdentifiers(db: Database, book: BookIdentifiersS
         isbn: eb.ref("excluded.isbn"),
         isbn13: eb.ref("excluded.isbn13"),
         goodreadsId: eb.ref("excluded.goodreadsId"),
+        // Preserve a previously-stored olWorkId if the new derive doesn't
+        // include one — most callers don't pass it through, so writing a
+        // bare null on conflict would clobber prior enrichment.
+        olWorkId: sql<string | null>`COALESCE(excluded.olWorkId, book_id_map.olWorkId)`,
         updatedAt: eb.ref("excluded.updatedAt"),
       })),
     )
@@ -157,6 +180,7 @@ export async function upsertBookIdentifiersBatch(db: Database, books: BookIdenti
       isbn: identifiers.isbn,
       isbn13: identifiers.isbn13,
       goodreadsId: identifiers.goodreadsId,
+      olWorkId: identifiers.olWorkId,
       updatedAt,
     };
   });
@@ -169,6 +193,7 @@ export async function upsertBookIdentifiersBatch(db: Database, books: BookIdenti
         isbn: eb.ref("excluded.isbn"),
         isbn13: eb.ref("excluded.isbn13"),
         goodreadsId: eb.ref("excluded.goodreadsId"),
+        olWorkId: sql<string | null>`COALESCE(excluded.olWorkId, book_id_map.olWorkId)`,
         updatedAt: eb.ref("excluded.updatedAt"),
       })),
     )

--- a/src/utils/bookMatching.test.ts
+++ b/src/utils/bookMatching.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from "bun:test";
+import {
+  bookEquivalenceKey,
+  contentWordsMatch,
+  normalizeCompact,
+  normalizeForMatch,
+  similarityScore,
+} from "./bookMatching";
+
+describe("normalizeForMatch", () => {
+  it("lowercases, strips punctuation, collapses whitespace", () => {
+    expect(normalizeForMatch("The Great Gatsby!")).toBe("the great gatsby");
+    expect(normalizeForMatch("  multiple   spaces  ")).toBe("multiple spaces");
+  });
+});
+
+describe("normalizeCompact", () => {
+  it("strips every non-alphanumeric character", () => {
+    expect(normalizeCompact("F. Scott Fitzgerald")).toBe("fscottfitzgerald");
+    expect(normalizeCompact("F Scott Fitzgerald")).toBe("fscottfitzgerald");
+  });
+});
+
+describe("similarityScore", () => {
+  it("returns 1 for exact normalized matches", () => {
+    expect(similarityScore("The Great Gatsby", "the great gatsby")).toBe(1);
+    expect(similarityScore("The Great Gatsby!", "The Great Gatsby")).toBe(1);
+  });
+
+  it("returns 0 for completely disjoint titles", () => {
+    expect(similarityScore("Foundation", "Cryptonomicon")).toBe(0);
+  });
+
+  it("scores partial overlap proportionally", () => {
+    const score = similarityScore("Children of Time", "Children of Ruin");
+    expect(score).toBeGreaterThan(0.5);
+    expect(score).toBeLessThan(1);
+  });
+});
+
+describe("contentWordsMatch", () => {
+  it("rejects series stem collisions", () => {
+    // The whole point of the gate: ditch series-mate false positives.
+    expect(contentWordsMatch("Children of Time", "Children of Ruin")).toBe(false);
+  });
+
+  it("allows the candidate to carry extra words (subtitles)", () => {
+    expect(contentWordsMatch("Foundation", "Foundation: The Empire Trilogy")).toBe(true);
+  });
+
+  it("ignores stop words and punctuation", () => {
+    expect(contentWordsMatch("The Lord of the Rings!", "lord of the rings")).toBe(true);
+  });
+
+  it("returns true when search has no content words", () => {
+    expect(contentWordsMatch("the and of", "anything")).toBe(true);
+  });
+});
+
+describe("bookEquivalenceKey", () => {
+  it("prefers olWorkId when present", () => {
+    expect(
+      bookEquivalenceKey({
+        title: "Foundation",
+        author: "Isaac Asimov",
+        olWorkId: "OL46125W",
+      }),
+    ).toBe("work:OL46125W");
+  });
+
+  it("falls back to compact title+author when olWorkId is missing", () => {
+    expect(
+      bookEquivalenceKey({
+        title: "F. Scott's Gatsby!",
+        author: "Fitzgerald",
+      }),
+    ).toBe("fuzzy:fscottsgatsby\0fitzgerald");
+  });
+
+  it("collapses punctuation/case variants", () => {
+    const a = bookEquivalenceKey({
+      title: "The Great Gatsby",
+      author: "F. Scott Fitzgerald",
+    });
+    const b = bookEquivalenceKey({
+      title: "the  great  gatsby",
+      author: "F Scott Fitzgerald",
+    });
+    expect(a).toBe(b);
+  });
+});

--- a/src/utils/bookMatching.ts
+++ b/src/utils/bookMatching.ts
@@ -1,0 +1,99 @@
+/**
+ * Fuzzy book matching helpers used as a fallback when exact identifier
+ * lookups (ISBN, Goodreads ID, OpenLibrary work ID) miss.
+ *
+ * Ported from the MIT-licensed shelfcheck project
+ * (`nowells/libby-reading-list` — `app/lib/libby.ts` and `app/lib/dedupe.ts`)
+ * with light adaptation for BookHive (tab-separated authors, HiveId).
+ */
+
+const STOP_WORDS = new Set([
+  "a",
+  "an",
+  "the",
+  "and",
+  "or",
+  "of",
+  "in",
+  "on",
+  "at",
+  "to",
+  "for",
+  "is",
+  "it",
+  "by",
+  "as",
+  "be",
+  "no",
+  "not",
+  "but",
+  "from",
+  "with",
+]);
+
+/** Lowercase, strip non-alphanumerics, collapse whitespace. */
+export function normalizeForMatch(input: string): string {
+  return input
+    .toLowerCase()
+    .replace(/[^a-z0-9\s]/g, "")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+/** Lowercase + strip every non-alphanumeric, used for fuzzy equivalence keys. */
+export function normalizeCompact(input: string): string {
+  return input.toLowerCase().replace(/[^a-z0-9]/g, "");
+}
+
+/** Significant words in `s` after stop-word removal. */
+export function contentWords(s: string): string[] {
+  return normalizeForMatch(s)
+    .split(" ")
+    .filter((w) => w.length > 0 && !STOP_WORDS.has(w));
+}
+
+/**
+ * Sørensen–Dice on whitespace-separated words after normalization.
+ * Returns 1 for an exact normalized match.
+ */
+export function similarityScore(a: string, b: string): number {
+  const na = normalizeForMatch(a);
+  const nb = normalizeForMatch(b);
+  if (na === nb) return 1;
+
+  const wordsA = na.split(" ").filter(Boolean);
+  const wordsB = nb.split(" ").filter(Boolean);
+  if (wordsA.length === 0 || wordsB.length === 0) return 0;
+
+  const setB = new Set(wordsB);
+  const intersection = wordsA.filter((w) => setB.has(w));
+  return (2 * intersection.length) / (wordsA.length + wordsB.length);
+}
+
+/**
+ * All-content-words gate: every significant word in `searchTitle` must
+ * appear in `candidateTitle`. Keeps "Children of Time" from accepting
+ * "Children of Ruin", which would otherwise share a high Dice score from
+ * the series stem.
+ */
+export function contentWordsMatch(searchTitle: string, candidateTitle: string): boolean {
+  const searchContent = contentWords(searchTitle);
+  if (searchContent.length === 0) return true;
+  const candidateContent = new Set(contentWords(candidateTitle));
+  return searchContent.every((w) => candidateContent.has(w));
+}
+
+/**
+ * "Same work" key. When both books have an OpenLibrary `workId` this is
+ * the most accurate equivalence; otherwise we fall back to a
+ * compact-normalized title+author hash so punctuation/case variants —
+ * "F. Scott Fitzgerald" vs "F Scott Fitzgerald" — collapse together.
+ */
+export function bookEquivalenceKey(book: {
+  title: string;
+  author: string;
+  olWorkId?: string | null;
+}): string {
+  if (book.olWorkId) return `work:${book.olWorkId.toUpperCase()}`;
+  return `fuzzy:${normalizeCompact(book.title)}\0${normalizeCompact(book.author)}`;
+}

--- a/src/utils/enrichBookData.ts
+++ b/src/utils/enrichBookData.ts
@@ -5,6 +5,7 @@ import { getBookDetailedInfo } from "../scrapers/moreInfo";
 import type { BookUtilContext } from "../context";
 import { normalizeGoodreadsId, upsertBookIdentifiers } from "./bookIdentifiers";
 import { Semaphore, withTimeout } from "./semaphore";
+import { lookupIsbn } from "./openLibrary";
 
 /**
  * Bounds enrichment for *every* caller, not just the ones we remembered to
@@ -35,7 +36,7 @@ interface BookMeta {
 
 export async function enrichBookWithDetailedData(
   book: HiveBook,
-  ctx: Pick<BookUtilContext, "db" | "addWideEventContext">,
+  ctx: Pick<BookUtilContext, "db" | "addWideEventContext"> & Partial<Pick<BookUtilContext, "kv">>,
   options?: { force?: boolean },
 ): Promise<void> {
   try {
@@ -100,7 +101,7 @@ export async function enrichBookWithDetailedData(
 /** The actual scrape + write. Runs inside the semaphore and the deadline. */
 async function enrich(
   book: HiveBook,
-  ctx: Pick<BookUtilContext, "db" | "addWideEventContext">,
+  ctx: Pick<BookUtilContext, "db" | "addWideEventContext"> & Partial<Pick<BookUtilContext, "kv">>,
 ): Promise<void> {
   if (!book.sourceUrl) return;
 
@@ -192,11 +193,28 @@ async function enrich(
     ? detailedData.book.id
     : book.sourceId;
 
-  await upsertBookIdentifiers(ctx.db, {
-    ...book,
-    sourceId: enrichedSourceId,
-    meta: serializedMeta,
-  });
+  let olWorkId: string | null = null;
+  if (ctx.kv) {
+    const isbnForLookup = updatedIdentifiers.isbn13 || updatedIdentifiers.isbn10;
+    if (isbnForLookup) {
+      try {
+        const enrichment = await lookupIsbn(ctx.kv, isbnForLookup);
+        olWorkId = enrichment?.workId ?? null;
+      } catch {
+        olWorkId = null;
+      }
+    }
+  }
+
+  await upsertBookIdentifiers(
+    ctx.db,
+    {
+      ...book,
+      sourceId: enrichedSourceId,
+      meta: serializedMeta,
+    },
+    { olWorkId },
+  );
 
   ctx.addWideEventContext({
     enrichment: "completed",

--- a/src/utils/findHiveBookMatch.test.ts
+++ b/src/utils/findHiveBookMatch.test.ts
@@ -1,0 +1,130 @@
+import { describe, expect, it } from "bun:test";
+import { Database as DatabaseSync } from "bun:sqlite";
+import { Kysely, SqliteDialect } from "kysely";
+import { wrapBunSqliteForKysely } from "../bun-sqlite-kysely";
+import { migrateToLatest, type DatabaseSchema } from "../db";
+import { findHiveBookMatch } from "./findHiveBookMatch";
+
+async function makeDb() {
+  const sqlite = new DatabaseSync(":memory:");
+  sqlite.exec("PRAGMA journal_mode = WAL");
+  const db = new Kysely<DatabaseSchema>({
+    dialect: new SqliteDialect({ database: wrapBunSqliteForKysely(sqlite) }),
+  });
+  await migrateToLatest(db, sqlite);
+  return { db, sqlite };
+}
+
+function seedHiveBook(
+  sqlite: DatabaseSync,
+  args: { id: string; rawTitle: string; title?: string; authors: string },
+) {
+  sqlite
+    .prepare(
+      `INSERT INTO hive_book (id, title, rawTitle, authors, cover, thumbnail, source, createdAt, updatedAt)
+       VALUES (?, ?, ?, ?, NULL, '', 'goodreads', datetime('now'), datetime('now'))`,
+    )
+    .run(args.id, args.title ?? args.rawTitle, args.rawTitle, args.authors);
+}
+
+function seedIdMap(
+  sqlite: DatabaseSync,
+  args: {
+    hiveId: string;
+    isbn?: string | null;
+    isbn13?: string | null;
+    goodreadsId?: string | null;
+  },
+) {
+  sqlite
+    .prepare(
+      `INSERT INTO book_id_map (hiveId, isbn, isbn13, goodreadsId, updatedAt)
+       VALUES (?, ?, ?, ?, datetime('now'))`,
+    )
+    .run(args.hiveId, args.isbn ?? null, args.isbn13 ?? null, args.goodreadsId ?? null);
+}
+
+describe("findHiveBookMatch", () => {
+  it("returns the exact match when title and author both line up", async () => {
+    const { db, sqlite } = await makeDb();
+    seedHiveBook(sqlite, {
+      id: "bk_exact",
+      rawTitle: "Foundation",
+      authors: "Isaac Asimov",
+    });
+
+    const result = await findHiveBookMatch(db, {
+      title: "Foundation",
+      author: "Isaac Asimov",
+    });
+
+    expect(result).not.toBeNull();
+    expect(result!.id).toBe("bk_exact");
+    expect(result!.matchedBy).toBe("exact");
+  });
+
+  it("falls back to ISBN-13 when title/author miss", async () => {
+    const { db, sqlite } = await makeDb();
+    seedHiveBook(sqlite, {
+      id: "bk_isbn",
+      rawTitle: "Foundation (different edition)",
+      authors: "Isaac Asimov",
+    });
+    seedIdMap(sqlite, { hiveId: "bk_isbn", isbn13: "9780553293357" });
+
+    const result = await findHiveBookMatch(db, {
+      title: "Foundation",
+      author: "Asimov, Isaac",
+      isbn13: "978-0-553-29335-7",
+    });
+
+    expect(result).not.toBeNull();
+    expect(result!.id).toBe("bk_isbn");
+    expect(result!.matchedBy).toBe("isbn13");
+  });
+
+  it("falls back to fuzzy when only an author casing differs", async () => {
+    const { db, sqlite } = await makeDb();
+    seedHiveBook(sqlite, {
+      id: "bk_fuzzy",
+      rawTitle: "The Great Gatsby",
+      authors: "F. Scott Fitzgerald",
+    });
+
+    const result = await findHiveBookMatch(db, {
+      title: "the great gatsby",
+      author: "F Scott Fitzgerald",
+    });
+
+    expect(result).not.toBeNull();
+    expect(result!.id).toBe("bk_fuzzy");
+    expect(result!.matchedBy).toBe("fuzzy");
+  });
+
+  it("does NOT match a series-mate via fuzzy fallback", async () => {
+    const { db, sqlite } = await makeDb();
+    // Only "Children of Ruin" exists; the importer is searching for
+    // "Children of Time". The contentWordsMatch gate must reject.
+    seedHiveBook(sqlite, {
+      id: "bk_ruin",
+      rawTitle: "Children of Ruin",
+      authors: "Adrian Tchaikovsky",
+    });
+
+    const result = await findHiveBookMatch(db, {
+      title: "Children of Time",
+      author: "Adrian Tchaikovsky",
+    });
+
+    expect(result).toBeNull();
+  });
+
+  it("returns null when nothing matches", async () => {
+    const { db } = await makeDb();
+    const result = await findHiveBookMatch(db, {
+      title: "A Book That Does Not Exist",
+      author: "Nobody",
+    });
+    expect(result).toBeNull();
+  });
+});

--- a/src/utils/findHiveBookMatch.ts
+++ b/src/utils/findHiveBookMatch.ts
@@ -1,0 +1,177 @@
+/**
+ * Resilient hive_book matcher used by the CSV importer when the strict
+ * `rawTitle = ? AND authors = ?` lookup misses. Layers identifier-based
+ * matching (ISBN-13 / Goodreads ID) on top of fuzzy title/author scoring
+ * powered by `bookMatching.ts`.
+ */
+import type { Database } from "../db";
+import type { HiveId } from "../types";
+import { normalizeGoodreadsId, normalizeIsbn, normalizeIsbn13 } from "./bookIdentifiers";
+import { contentWords, contentWordsMatch, similarityScore } from "./bookMatching";
+
+const FUZZY_TITLE_THRESHOLD = 0.6;
+const FUZZY_AUTHOR_THRESHOLD = 0.6;
+const MAX_CANDIDATES = 50;
+
+type HiveBookMatchRow = {
+  id: HiveId;
+  title: string;
+  cover: string | null;
+  identifiers: string | null;
+};
+
+export type HiveBookMatch = HiveBookMatchRow & { matchedBy: MatchSource };
+
+export type MatchSource = "exact" | "isbn13" | "goodreadsId" | "fuzzy";
+
+export type FindHiveBookMatchInput = {
+  title: string;
+  author: string;
+  /** Either an ISBN-10 or ISBN-13. The matcher routes to the right column. */
+  isbn?: string | null;
+  isbn13?: string | null;
+  goodreadsId?: string | null;
+};
+
+/**
+ * Fast-path: identifier lookups via `book_id_map`. Only returns a hit when
+ * we can confidently map the imported row to a single `hive_book.id`.
+ */
+async function findByIdentifier(
+  db: Database,
+  input: FindHiveBookMatchInput,
+): Promise<{ row: HiveBookMatchRow; matchedBy: MatchSource } | null> {
+  // Treat any 13-digit value (whether passed as `isbn13` or `isbn`) as
+  // ISBN-13, and any 10-digit value as ISBN-10.
+  const candidateIsbn13 = [input.isbn13, input.isbn]
+    .map((v) => normalizeIsbn13(v))
+    .find((v) => v && v.length === 13);
+  if (candidateIsbn13) {
+    const row = await db
+      .selectFrom("hive_book")
+      .innerJoin("book_id_map", "book_id_map.hiveId", "hive_book.id")
+      .select(["hive_book.id", "hive_book.title", "hive_book.cover", "hive_book.identifiers"])
+      .where("book_id_map.isbn13", "=", candidateIsbn13)
+      .executeTakeFirst();
+    if (row) return { row, matchedBy: "isbn13" };
+  }
+
+  const candidateIsbn10 = [input.isbn, input.isbn13]
+    .map((v) => normalizeIsbn(v))
+    .find((v) => v && v.length === 10);
+  if (candidateIsbn10) {
+    const row = await db
+      .selectFrom("hive_book")
+      .innerJoin("book_id_map", "book_id_map.hiveId", "hive_book.id")
+      .select(["hive_book.id", "hive_book.title", "hive_book.cover", "hive_book.identifiers"])
+      .where("book_id_map.isbn", "=", candidateIsbn10)
+      .executeTakeFirst();
+    if (row) return { row, matchedBy: "isbn13" };
+  }
+
+  const goodreadsId = normalizeGoodreadsId(input.goodreadsId);
+  if (goodreadsId) {
+    const row = await db
+      .selectFrom("hive_book")
+      .innerJoin("book_id_map", "book_id_map.hiveId", "hive_book.id")
+      .select(["hive_book.id", "hive_book.title", "hive_book.cover", "hive_book.identifiers"])
+      .where("book_id_map.goodreadsId", "=", goodreadsId)
+      .executeTakeFirst();
+    if (row) return { row, matchedBy: "goodreadsId" };
+  }
+
+  return null;
+}
+
+/**
+ * Fuzzy fallback: pull candidate hive_book rows whose `rawTitle` shares
+ * the imported title's first significant word, then locally rank by
+ * `similarityScore` and gate with `contentWordsMatch` so series-mate
+ * collisions don't slip through.
+ */
+async function findByFuzzy(
+  db: Database,
+  input: FindHiveBookMatchInput,
+): Promise<HiveBookMatchRow | null> {
+  const titleWords = contentWords(input.title);
+  if (titleWords.length === 0) return null;
+  const firstWord = titleWords[0]!;
+
+  // The leading content word almost always survives editor edits ("The
+  // Great Gatsby" / "Great Gatsby") so this prefix prefilter is cheap and
+  // correct enough to avoid scanning the whole table.
+  const candidates = await db
+    .selectFrom("hive_book")
+    .select(["id", "title", "rawTitle", "authors", "cover", "identifiers"])
+    .where(
+      // SQLite LIKE is case-insensitive for ASCII by default — matches
+      // "The Great Gatsby", "the great gatsby", etc.
+      (eb) =>
+        eb.or([
+          eb("hive_book.rawTitle", "like", `%${firstWord}%`),
+          eb("hive_book.title", "like", `%${firstWord}%`),
+        ]),
+    )
+    .limit(MAX_CANDIDATES)
+    .execute();
+
+  let best: { row: HiveBookMatchRow; score: number } | null = null;
+  for (const candidate of candidates) {
+    const titleScore = similarityScore(input.title, candidate.rawTitle ?? candidate.title);
+    if (titleScore < FUZZY_TITLE_THRESHOLD) continue;
+    if (!contentWordsMatch(input.title, candidate.rawTitle ?? candidate.title)) continue;
+
+    // `authors` is tab-separated. Score against the best individual author.
+    const authorList = (candidate.authors ?? "").split("\t").filter(Boolean);
+    const authorScore = authorList.length
+      ? Math.max(...authorList.map((a) => similarityScore(input.author, a)))
+      : 0;
+    if (authorScore < FUZZY_AUTHOR_THRESHOLD) continue;
+
+    const combined = (titleScore + authorScore) / 2;
+    if (!best || combined > best.score) {
+      best = {
+        score: combined,
+        row: {
+          id: candidate.id,
+          title: candidate.title,
+          cover: candidate.cover,
+          identifiers: candidate.identifiers,
+        },
+      };
+    }
+  }
+
+  return best?.row ?? null;
+}
+
+/**
+ * Match an imported book row to a canonical `hive_book` record. Returns
+ * `null` when no confident match is found.
+ */
+export async function findHiveBookMatch(
+  db: Database,
+  input: FindHiveBookMatchInput,
+): Promise<HiveBookMatch | null> {
+  // Phase 1: exact title/author. Mirrors the original importer query so
+  // it stays the cheapest path when CSV titles match canonical ones.
+  const exact = await db
+    .selectFrom("hive_book")
+    .select(["id", "title", "cover", "identifiers"])
+    .where("hive_book.rawTitle", "=", input.title)
+    .where("authors", "=", input.author)
+    .executeTakeFirst();
+  if (exact) return { ...exact, matchedBy: "exact" };
+
+  // Phase 2: identifier lookups (book_id_map already deduped by hiveId).
+  const byId = await findByIdentifier(db, input);
+  if (byId) return { ...byId.row, matchedBy: byId.matchedBy };
+
+  // Phase 3: fuzzy title/author fallback.
+  const fuzzy = await findByFuzzy(db, input);
+  if (fuzzy) return { ...fuzzy, matchedBy: "fuzzy" };
+
+  return null;
+}
+
+export type { HiveId };

--- a/src/utils/openLibrary.test.ts
+++ b/src/utils/openLibrary.test.ts
@@ -1,0 +1,74 @@
+import { afterEach, beforeEach, describe, expect, it, mock } from "bun:test";
+import { createStorage } from "unstorage";
+import memoryDriver from "unstorage/drivers/memory";
+import { lookupIsbn, parseEdition } from "./openLibrary";
+
+describe("parseEdition", () => {
+  it("extracts workId and trimmed title", () => {
+    expect(
+      parseEdition({
+        title: "  Foundation  ",
+        works: [{ key: "/works/OL46125W" }],
+      }),
+    ).toEqual({ workId: "OL46125W", canonicalTitle: "Foundation" });
+  });
+
+  it("returns null when works is missing", () => {
+    expect(parseEdition({ title: "x" })).toBe(null);
+  });
+
+  it("returns null on garbage input", () => {
+    expect(parseEdition(null)).toBe(null);
+    expect(parseEdition("nope")).toBe(null);
+    expect(parseEdition({ works: [{ key: "/authors/OL12A" }] })).toBe(null);
+  });
+});
+
+describe("lookupIsbn", () => {
+  const originalFetch = globalThis.fetch;
+
+  beforeEach(() => {
+    // Each test installs its own mock; just guard against leaks.
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  it("resolves and caches successful responses", async () => {
+    const kv = createStorage({ driver: memoryDriver() });
+    const fetchMock = mock(async () => {
+      return new Response(
+        JSON.stringify({ title: "Foundation", works: [{ key: "/works/OL46125W" }] }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      );
+    });
+    globalThis.fetch = fetchMock as unknown as typeof globalThis.fetch;
+
+    const first = await lookupIsbn(kv, "9780553293357");
+    expect(first).toEqual({ workId: "OL46125W", canonicalTitle: "Foundation" });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    const second = await lookupIsbn(kv, "9780553293357");
+    expect(second).toEqual({ workId: "OL46125W", canonicalTitle: "Foundation" });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns null and does not throw on 404", async () => {
+    const kv = createStorage({ driver: memoryDriver() });
+    globalThis.fetch = mock(
+      async () => new Response("", { status: 404 }),
+    ) as unknown as typeof globalThis.fetch;
+    expect(await lookupIsbn(kv, "9780000000000")).toBe(null);
+  });
+
+  it("rejects malformed ISBNs without calling fetch", async () => {
+    const kv = createStorage({ driver: memoryDriver() });
+    const fetchMock = mock(async () => new Response(""));
+    globalThis.fetch = fetchMock as unknown as typeof globalThis.fetch;
+
+    expect(await lookupIsbn(kv, "")).toBe(null);
+    expect(await lookupIsbn(kv, "12345")).toBe(null);
+    expect(fetchMock).toHaveBeenCalledTimes(0);
+  });
+});

--- a/src/utils/openLibrary.ts
+++ b/src/utils/openLibrary.ts
@@ -1,0 +1,74 @@
+import type { Storage } from "unstorage";
+import { normalizeIsbn13, normalizeOlWorkId } from "./bookIdentifiers";
+import { readThroughCache } from "./readThroughCache";
+
+/**
+ * Server-side OpenLibrary ISBN→workId lookup, KV-cached.
+ *
+ * Ported (loosely) from the MIT-licensed shelfcheck project's
+ * `app/lib/openlibrary.ts`. Shelfcheck caches in browser localStorage; here
+ * we go through `kvStore` so every server hit benefits the next request.
+ */
+
+const BASE = "https://openlibrary.org";
+const KV_PREFIX = "bookhive:ol-isbn:";
+const POSITIVE_TTL_MS = 30 * 24 * 60 * 60 * 1000;
+
+export type OpenLibraryEnrichment = {
+  workId: string;
+  canonicalTitle: string | null;
+};
+
+type OpenLibraryEditionResponse = {
+  title?: string;
+  works?: { key?: string }[];
+};
+
+/** Extract the workId (e.g. "OL45883W") from an Open Library edition JSON. */
+export function parseEdition(payload: unknown): OpenLibraryEnrichment | null {
+  if (!payload || typeof payload !== "object") return null;
+  const ed = payload as OpenLibraryEditionResponse;
+  const workKey = ed.works?.[0]?.key;
+  if (typeof workKey !== "string") return null;
+  const workId = normalizeOlWorkId(workKey);
+  if (!workId) return null;
+  const canonicalTitle =
+    typeof ed.title === "string" && ed.title.trim().length > 0 ? ed.title.trim() : null;
+  return { workId, canonicalTitle };
+}
+
+async function fetchByIsbn(isbn: string): Promise<OpenLibraryEnrichment | null> {
+  try {
+    const res = await fetch(`${BASE}/isbn/${isbn}.json`, {
+      headers: { Accept: "application/json" },
+    });
+    if (res.status === 404) return null;
+    if (!res.ok) return null;
+    const json = await res.json();
+    return parseEdition(json);
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Look up an ISBN-10/13 on OpenLibrary and return its workId. Successful
+ * responses (including a confirmed 404 → `null`) are cached for 30 days
+ * via `readThroughCache`. Network/parse failures fall through without
+ * polluting the cache so the next request can retry.
+ */
+export async function lookupIsbn(
+  kv: Storage,
+  isbnInput: string,
+): Promise<OpenLibraryEnrichment | null> {
+  const isbn = normalizeIsbn13(isbnInput);
+  if (!isbn || (isbn.length !== 10 && isbn.length !== 13)) return null;
+
+  return readThroughCache<OpenLibraryEnrichment | null>(
+    kv as Storage<OpenLibraryEnrichment | null>,
+    `${KV_PREFIX}${isbn}`,
+    () => fetchByIsbn(isbn),
+    null,
+    { ttl: POSITIVE_TTL_MS, requestsPerSecond: 5 },
+  );
+}

--- a/src/workers/import/logic.ts
+++ b/src/workers/import/logic.ts
@@ -25,6 +25,7 @@ import {
   buildStorygraphBookRecord,
   deduplicateUnmatchedWithDetails,
 } from "../../utils/importBook";
+import { findHiveBookMatch } from "../../utils/findHiveBookMatch";
 // Note: Worker threads get isolated metric registries, so metrics here won't appear
 // at the main /metrics endpoint. The main thread (routes/import.ts) tracks import
 // duration and active operations. Per-book counts are conveyed via SSE events.
@@ -285,12 +286,13 @@ export async function processGoodreadsImport({
       // Await this book's search (others in the chunk are already in-flight)
       await searches[j];
 
-      const hiveBook = await ctx.db
-        .selectFrom("hive_book")
-        .select(["id", "title", "cover", "identifiers"])
-        .where("hive_book.rawTitle", "=", book.title)
-        .where("authors", "=", book.author)
-        .executeTakeFirst();
+      const hiveBook = await findHiveBookMatch(ctx.db, {
+        title: book.title,
+        author: book.author,
+        isbn: book.isbn,
+        isbn13: book.isbn13,
+        goodreadsId: book.bookId,
+      });
 
       if (!hiveBook) {
         const key = `${normalizeStr(book.title)}::${normalizeStr(book.author)}`;
@@ -508,12 +510,13 @@ export async function processStorygraphImport({
 
       await searches[j];
 
-      const hiveBook = await ctx.db
-        .selectFrom("hive_book")
-        .select(["id", "title", "cover", "identifiers"])
-        .where("hive_book.rawTitle", "=", book.title)
-        .where("authors", "=", book.authors)
-        .executeTakeFirst();
+      const hiveBook = await findHiveBookMatch(ctx.db, {
+        title: book.title,
+        author: book.authors,
+        // StoryGraph stores either an ISBN-10 or ISBN-13 in `isbn`; the
+        // matcher routes by length.
+        isbn: book.isbn,
+      });
 
       if (!hiveBook) {
         const key = `${normalizeStr(book.title)}::${normalizeStr(book.authors)}`;


### PR DESCRIPTION
## Summary

- Adds a **Libby availability badge** on want-to-read books in the library table and a dedicated `/libby` page for bulk shelf-checking against local library availability via the Libby/OverDrive API.
- Introduces an **OpenLibrary ISBN lookup** utility (`src/utils/openLibrary.ts`) with KV caching, used during Goodreads enrichment to resolve and persist OpenLibrary work IDs in a new `book_id_map.olWorkId` column (migration 022).
- Replaces the rigid exact-match book lookup in CSV imports with a **fuzzy `findHiveBookMatch`** helper that tries ISBN, Goodreads ID, title+author, and normalized-title fallbacks — improving match rates for Goodreads and StoryGraph imports.
- New client-side components: `LibbyBadge`, `LibbyShelf`, and supporting utilities for Libby API calls and local storage of library card info.

## Test plan

- [ ] Verify `/libby` page loads and allows entering a library card
- [ ] Confirm Libby badges appear on want-to-read books in the profile library table
- [ ] Run `bun test src` — new tests cover `bookMatching`, `findHiveBookMatch`, and `openLibrary`
- [ ] Test a Goodreads/StoryGraph CSV import to confirm fuzzy matching works
- [ ] Verify enrichment still works and populates `olWorkId` in `book_id_map`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a Libby page for checking want-to-read books across selected libraries.
  - Search, select, add, and remove libraries, with availability details, hold estimates, and direct title links.
  - Added availability badges to want-to-read books in desktop and mobile library views.
  - Added cached results, loading states, retries, and a “check all” action.
- **Improvements**
  - Enhanced book matching using ISBNs, external identifiers, and fuzzy title/author matching.
  - Added Open Library work identifiers to improve book recognition and enrichment.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->