### PR TITLE
feat: support orphan book pages for books without a hiveId

### DIFF
--- a/app/app/(tabs)/books/[status].tsx
+++ b/app/app/(tabs)/books/[status].tsx
@@ -451,7 +451,7 @@ function FilteredBooksContent({ status, did }: { status: string; did?: string })
         <FlatList
           data={filteredBooks}
           renderItem={renderBook}
-          keyExtractor={(item) => item.hiveId}
+          keyExtractor={(item) => item.uri ?? item.hiveId ?? `${item.userDid}-${item.title}`}
           contentContainerStyle={styles.listContainer}
           showsVerticalScrollIndicator={false}
         />

--- a/app/app/(tabs)/feed.tsx
+++ b/app/app/(tabs)/feed.tsx
@@ -44,7 +44,9 @@ const BOOK_STATUS_LABELS: Record<string, string> = {
 type FeedActivity = {
   userDid: string;
   userHandle?: string;
-  hiveId: string;
+  /** Absent for orphan / foreign-lexicon records — fall back to `uri` for keys/navigation. */
+  hiveId?: string;
+  uri: string;
   title: string;
   authors: string;
   status?: string;
@@ -72,11 +74,9 @@ export default function FeedScreen() {
   const activities = useMemo(() => {
     const currentPageActivities = feed.data?.activities ?? [];
     if (page === 1) return currentPageActivities;
-    // Deduplicate by composite key
-    const seen = new Set(allActivities.map((a) => `${a.hiveId}_${a.userDid}_${a.createdAt}`));
-    const newItems = currentPageActivities.filter(
-      (a) => !seen.has(`${a.hiveId}_${a.userDid}_${a.createdAt}`),
-    );
+    // Dedupe on uri (always unique per row) so orphan rows aren't collapsed.
+    const seen = new Set(allActivities.map((a) => a.uri));
+    const newItems = currentPageActivities.filter((a) => !seen.has(a.uri));
     return [...allActivities, ...newItems];
   }, [feed.data?.activities, page, allActivities]);
 
@@ -116,7 +116,7 @@ export default function FeedScreen() {
           title={item.title}
           authors={item.authors}
           imageUri={`${getBaseUrl()}/images/s_300x500,fit_cover,extend_5_5_5_5,b_030712/${item.cover || item.thumbnail}`}
-          onPress={() => router.push(`/book/${item.hiveId}` as any)}
+          onPress={() => (item.hiveId ? router.push(`/book/${item.hiveId}` as any) : undefined)}
           variant="list"
         >
           <UserBlock
@@ -217,7 +217,7 @@ export default function FeedScreen() {
       ) : (
         <FlatList
           data={activities}
-          keyExtractor={(item) => `${item.hiveId}_${item.userDid}_${item.createdAt}`}
+          keyExtractor={(item) => item.uri}
           numColumns={2}
           columnWrapperStyle={styles.gridRow}
           style={styles.feedList}

--- a/app/app/(tabs)/index.tsx
+++ b/app/app/(tabs)/index.tsx
@@ -34,19 +34,22 @@ const MAX_BOOKS_PER_SECTION = 20;
 function BookGrid({ books }: { books: UserBook[]; colors: any }) {
   return (
     <View style={styles.gridContainer}>
-      {books.map((book, index) => (
-        <View key={book.hiveId} style={styles.gridItem}>
-          <AnimatedListItem index={index}>
-            <BookCard
-              title={book.title}
-              authors={book.authors}
-              imageUri={`${getBaseUrl()}/images/s_300x500,fit_cover,extend_5_5_5_5,b_030712/${book.cover || book.thumbnail}`}
-              onPress={() => router.push(`/book/${book.hiveId}`)}
-              variant="dense"
-            />
-          </AnimatedListItem>
-        </View>
-      ))}
+      {books.map((book, index) => {
+        const key = book.uri ?? book.hiveId ?? `${book.userDid}-${book.title}-${index}`;
+        return (
+          <View key={key} style={styles.gridItem}>
+            <AnimatedListItem index={index}>
+              <BookCard
+                title={book.title}
+                authors={book.authors}
+                imageUri={`${getBaseUrl()}/images/s_300x500,fit_cover,extend_5_5_5_5,b_030712/${book.cover || book.thumbnail}`}
+                onPress={() => (book.hiveId ? router.push(`/book/${book.hiveId}`) : undefined)}
+                variant="dense"
+              />
+            </AnimatedListItem>
+          </View>
+        );
+      })}
     </View>
   );
 }

--- a/app/app/(tabs)/profile/[did].tsx
+++ b/app/app/(tabs)/profile/[did].tsx
@@ -108,12 +108,12 @@ export default function ProfileScreen() {
     );
   }
 
-  // Dedupe by hiveId to avoid duplicate keys in FlatLists
-  const dedupeByHiveId = <T extends { hiveId: string }>(books: T[]) => {
+  // Dedupe by uri (always present), hiveId is optional.
+  const dedupeByUri = <T extends { uri?: string; hiveId?: string }>(books: T[]) => {
     const seen = new Set<string>();
     const unique: T[] = [];
     for (const book of books) {
-      const key = String(book.hiveId);
+      const key = book.uri ?? book.hiveId ?? "";
       if (!seen.has(key)) {
         seen.add(key);
         unique.push(book);
@@ -122,19 +122,23 @@ export default function ProfileScreen() {
     return unique;
   };
 
-  const readingBooks = dedupeByHiveId(
+  const bookKey = (book: { uri?: string; hiveId?: string }) => book.uri ?? book.hiveId ?? "";
+
+  const readingBooks = dedupeByUri(
     profile.data.books.filter((book) => book.status === BOOK_STATUS.READING),
   );
-  const wantToReadBooks = dedupeByHiveId(
+  const wantToReadBooks = dedupeByUri(
     profile.data.books.filter((book) => book.status === BOOK_STATUS.WANTTOREAD),
   );
-  const readBooks = dedupeByHiveId(
+  const readBooks = dedupeByUri(
     profile.data.books.filter((book) => book.status === BOOK_STATUS.FINISHED),
   );
 
   const renderBookItem = ({ item: book }: { item: any }) => (
     <Pressable
-      onPress={() => router.push(`/book/${book.hiveId}`)}
+      // Orphan rows (no hiveId) aren't navigable yet — disable the press.
+      onPress={() => (book.hiveId ? router.push(`/book/${book.hiveId}`) : undefined)}
+      disabled={!book.hiveId}
       style={[
         styles.bookItem,
         {
@@ -346,7 +350,7 @@ export default function ProfileScreen() {
             </Pressable>
             <FlatList
               data={readingBooks}
-              keyExtractor={(item) => item.hiveId}
+              keyExtractor={(item) => bookKey(item)}
               renderItem={renderBookItem}
               horizontal
               showsHorizontalScrollIndicator={false}
@@ -385,7 +389,7 @@ export default function ProfileScreen() {
             </Pressable>
             <FlatList
               data={wantToReadBooks}
-              keyExtractor={(item) => item.hiveId}
+              keyExtractor={(item) => bookKey(item)}
               renderItem={renderBookItem}
               horizontal
               showsHorizontalScrollIndicator={false}
@@ -424,7 +428,7 @@ export default function ProfileScreen() {
             </Pressable>
             <FlatList
               data={readBooks}
-              keyExtractor={(item) => item.hiveId}
+              keyExtractor={(item) => bookKey(item)}
               renderItem={renderBookItem}
               horizontal
               showsHorizontalScrollIndicator={false}

--- a/app/hooks/useBookhiveQuery.ts
+++ b/app/hooks/useBookhiveQuery.ts
@@ -345,7 +345,8 @@ export const useFeed = (tab: "friends" | "all" | "tracking" = "friends", page: n
         activities: {
           userDid: string;
           userHandle?: string;
-          hiveId: string;
+          hiveId?: string;
+          uri: string;
           title: string;
           authors: string;
           status?: string;

--- a/lexicons/defs.json
+++ b/lexicons/defs.json
@@ -110,7 +110,7 @@
     },
     "activity": {
       "type": "object",
-      "required": ["type", "createdAt", "hiveId", "title", "userDid", "userHandle"],
+      "required": ["type", "createdAt", "title", "userDid", "userHandle"],
       "properties": {
         "type": {
           "type": "string",
@@ -122,7 +122,11 @@
         },
         "hiveId": {
           "type": "string",
-          "description": "The hive id of the book"
+          "description": "The hive id of the book. Absent for foreign-lexicon or unresolved records — clients should fall back to the user-scoped record (uri) for navigation."
+        },
+        "uri": {
+          "type": "string",
+          "description": "AT-URI of the user's PDS record for this book. Always present; use this as a stable identifier when hiveId is missing."
         },
         "title": {
           "type": "string",
@@ -140,7 +144,7 @@
     },
     "userBook": {
       "type": "object",
-      "required": ["userDid", "title", "authors", "hiveId", "createdAt", "thumbnail"],
+      "required": ["userDid", "title", "authors", "createdAt", "thumbnail"],
       "properties": {
         "userDid": {
           "type": "string",
@@ -164,7 +168,11 @@
         },
         "hiveId": {
           "type": "string",
-          "description": "The book's hive id, used to correlate user's books with the hive"
+          "description": "The book's hive id, used to correlate the user's book with the hive catalog. Absent for foreign-lexicon imports (e.g. Popfeed) or records the catalog hasn't yet matched. Clients should fall back to `uri` for stable identity."
+        },
+        "uri": {
+          "type": "string",
+          "description": "AT-URI of the user's PDS record. Always present; use as a stable identifier and for the user-scoped detail page when hiveId is missing."
         },
         "createdAt": {
           "type": "string",

--- a/lexicons/getFeed.json
+++ b/lexicons/getFeed.json
@@ -4,11 +4,18 @@
   "defs": {
     "feedActivity": {
       "type": "object",
-      "required": ["userDid", "hiveId", "title", "authors", "createdAt", "thumbnail"],
+      "required": ["userDid", "title", "authors", "createdAt", "thumbnail", "uri"],
       "properties": {
         "userDid": { "type": "string" },
         "userHandle": { "type": "string" },
-        "hiveId": { "type": "string" },
+        "hiveId": {
+          "type": "string",
+          "description": "Optional — absent for foreign-lexicon or unresolved records. Fall back to `uri` for navigation."
+        },
+        "uri": {
+          "type": "string",
+          "description": "AT-URI of the user's PDS record; always present and unique per row."
+        },
         "title": { "type": "string" },
         "authors": { "type": "string" },
         "status": { "type": "string" },

--- a/src/bsky/ingester.ts
+++ b/src/bsky/ingester.ts
@@ -134,37 +134,29 @@ async function backfillUserRepo(
           });
 
           if (validBooks.length > 0) {
-            // Batch-fetch which hiveIds exist
-            const requestedHiveIds = validBooks.map((r) => r.book.hiveId as HiveId);
-            const existingBooks = await db
-              .selectFrom("hive_book")
-              .select("id")
-              .where("id", "in", requestedHiveIds)
-              .execute();
-            const existingHiveIds = new Set(existingBooks.map((b) => b.id));
-
-            const rowsToInsert = validBooks
-              .filter(({ book }) => existingHiveIds.has(book.hiveId as HiveId))
-              .map(({ record, book }) =>
-                serializeUserBook({
-                  uri: record.uri,
-                  cid: record.cid,
-                  userDid: did,
-                  hiveId: book.hiveId as HiveId,
-                  createdAt: book.createdAt,
-                  indexedAt: now.toISOString(),
-                  title: book.title,
-                  authors: book.authors,
-                  startedAt: book.startedAt ?? null,
-                  finishedAt: book.finishedAt ?? null,
-                  status: book.status ?? null,
-                  owned: book.owned ? 1 : 0,
-                  review: book.review ?? null,
-                  stars: book.stars ?? null,
-                  bookProgress: book.bookProgress ?? null,
-                  previousReads: book.previousReads ?? null,
-                } satisfies UserBook),
-              );
+            // Insert every valid record. hive_book is a denormalized cache that
+            // gets populated asynchronously via searchBooks; rows whose hiveId
+            // doesn't yet have a hive_book row will join cleanly once it does.
+            const rowsToInsert = validBooks.map(({ record, book }) =>
+              serializeUserBook({
+                uri: record.uri,
+                cid: record.cid,
+                userDid: did,
+                hiveId: book.hiveId as HiveId,
+                createdAt: book.createdAt,
+                indexedAt: now.toISOString(),
+                title: book.title,
+                authors: book.authors,
+                startedAt: book.startedAt ?? null,
+                finishedAt: book.finishedAt ?? null,
+                status: book.status ?? null,
+                owned: book.owned ? 1 : 0,
+                review: book.review ?? null,
+                stars: book.stars ?? null,
+                bookProgress: book.bookProgress ?? null,
+                previousReads: book.previousReads ?? null,
+              } satisfies UserBook),
+            );
             for (let i = 0; i < rowsToInsert.length; i += 100) {
               await db
                 .insertInto("user_book")
@@ -191,7 +183,7 @@ async function backfillUserRepo(
             const uriToHiveId = new Map(bookRows.map((r) => [r.uri, r.hiveId]));
 
             const buzzRows = validBuzzes
-              .filter(({ buzz }) => uriToHiveId.has(buzz.book.uri))
+              .filter(({ buzz }) => uriToHiveId.get(buzz.book.uri) != null)
               .map(
                 ({ record, buzz }) =>
                   ({
@@ -386,6 +378,10 @@ export function createIngester(
               .where("id", "=", (record as Record<string, unknown>)["hiveId"] as HiveId)
               .executeTakeFirst()
           )?.id;
+          // Missing hive_book row no longer blocks ingestion. We still insert
+          // the user_book using the PDS record's embedded title/authors/cover
+          // (the lexicon guarantees those + hiveId), and kick off a background
+          // search so a future hive_book row resolves the join.
           if (!hiveId) {
             tracked("searchBooks", evt.did, () =>
               searchBooks({
@@ -393,12 +389,6 @@ export function createIngester(
                 ctx: { db, kv, addWideEventContext: () => {} },
               }),
             );
-            wideEvent["outcome"] = "error";
-            wideEvent["error"] = {
-              message: "hiveId not found, triggered search",
-              record_uri: evt.uri.toString(),
-            };
-            return;
           }
           const isNewDid = !backfilledDids.has(evt.did);
           await db
@@ -444,7 +434,7 @@ export function createIngester(
             )
             .execute();
 
-          if (serviceAccountAgent) {
+          if (hiveId && serviceAccountAgent) {
             tracked("writeCatalogBook", evt.did, () =>
               writeCatalogBookIfNeeded({ db, serviceAccountAgent }, hiveId),
             );
@@ -460,7 +450,7 @@ export function createIngester(
             });
           }
 
-          wideEvent["outcome"] = "success";
+          wideEvent["outcome"] = hiveId ? "success" : "success_unresolved";
           return;
         }
         if (evt.collection === ids.BuzzBookhiveBuzz) {

--- a/src/bsky/lexicon/generated/types/buzz/bookhive/defs.ts
+++ b/src/bsky/lexicon/generated/types/buzz/bookhive/defs.ts
@@ -7,14 +7,18 @@ const _activitySchema = /*#__PURE__*/ v.object({
   $type: /*#__PURE__*/ v.optional(/*#__PURE__*/ v.literal("buzz.bookhive.defs#activity")),
   createdAt: /*#__PURE__*/ v.datetimeString(),
   /**
-   * The hive id of the book
+   * The hive id of the book. Absent for foreign-lexicon or unresolved records — clients should fall back to the user-scoped record (uri) for navigation.
    */
-  hiveId: /*#__PURE__*/ v.string(),
+  hiveId: /*#__PURE__*/ v.optional(/*#__PURE__*/ v.string()),
   /**
    * The title of the book
    */
   title: /*#__PURE__*/ v.string(),
   type: /*#__PURE__*/ v.string<"finished" | "rated" | "review" | "started" | (string & {})>(),
+  /**
+   * AT-URI of the user's PDS record for this book. Always present; use this as a stable identifier when hiveId is missing.
+   */
+  uri: /*#__PURE__*/ v.optional(/*#__PURE__*/ v.string()),
   /**
    * The DID of the user who added the book
    */
@@ -223,9 +227,9 @@ const _userBookSchema = /*#__PURE__*/ v.object({
    */
   genres: /*#__PURE__*/ v.optional(/*#__PURE__*/ v.array(/*#__PURE__*/ v.string())),
   /**
-   * The book's hive id, used to correlate user's books with the hive
+   * The book's hive id, used to correlate the user's book with the hive catalog. Absent for foreign-lexicon imports (e.g. Popfeed) or records the catalog hasn't yet matched. Clients should fall back to `uri` for stable identity.
    */
-  hiveId: /*#__PURE__*/ v.string(),
+  hiveId: /*#__PURE__*/ v.optional(/*#__PURE__*/ v.string()),
   /**
    * External identifiers for the book
    */
@@ -297,6 +301,10 @@ const _userBookSchema = /*#__PURE__*/ v.object({
   title: /*#__PURE__*/ v.constrain(/*#__PURE__*/ v.string(), [
     /*#__PURE__*/ v.stringLength(1, 512),
   ]),
+  /**
+   * AT-URI of the user's PDS record. Always present; use as a stable identifier and for the user-scoped detail page when hiveId is missing.
+   */
+  uri: /*#__PURE__*/ v.optional(/*#__PURE__*/ v.string()),
   /**
    * The DID of the user who added the book
    */

--- a/src/bsky/lexicon/generated/types/buzz/bookhive/getFeed.ts
+++ b/src/bsky/lexicon/generated/types/buzz/bookhive/getFeed.ts
@@ -7,7 +7,10 @@ const _feedActivitySchema = /*#__PURE__*/ v.object({
   authors: /*#__PURE__*/ v.string(),
   cover: /*#__PURE__*/ v.optional(/*#__PURE__*/ v.string()),
   createdAt: /*#__PURE__*/ v.datetimeString(),
-  hiveId: /*#__PURE__*/ v.string(),
+  /**
+   * Optional — absent for foreign-lexicon or unresolved records. Fall back to `uri` for navigation.
+   */
+  hiveId: /*#__PURE__*/ v.optional(/*#__PURE__*/ v.string()),
   review: /*#__PURE__*/ v.optional(/*#__PURE__*/ v.string()),
   /**
    * @minimum 1
@@ -19,6 +22,10 @@ const _feedActivitySchema = /*#__PURE__*/ v.object({
   status: /*#__PURE__*/ v.optional(/*#__PURE__*/ v.string()),
   thumbnail: /*#__PURE__*/ v.string(),
   title: /*#__PURE__*/ v.string(),
+  /**
+   * AT-URI of the user's PDS record; always present and unique per row.
+   */
+  uri: /*#__PURE__*/ v.string(),
   userAvatar: /*#__PURE__*/ v.optional(/*#__PURE__*/ v.string()),
   userDid: /*#__PURE__*/ v.string(),
   userHandle: /*#__PURE__*/ v.optional(/*#__PURE__*/ v.string()),

--- a/src/client/components/LibraryTable.tsx
+++ b/src/client/components/LibraryTable.tsx
@@ -11,7 +11,14 @@ import {
 } from "./bookActions";
 
 type LibraryBook = {
-  hiveId: string;
+  /** Null for orphan rows (no hive_book yet); use bookUri to identify in API calls. */
+  hiveId: string | null;
+  /** AT-URI of the user's PDS record. Always present. Used as React key + identifier. */
+  bookUri: string;
+  /** Pre-computed link target: /books/:hiveId when hive-backed, else /profile/:handle/book/:rkey. */
+  bookHref: string;
+  /** Pre-computed delete target: same path conventions as bookHref. */
+  deleteUrl: string;
   title: string;
   authors: string;
   cover?: string | null;
@@ -27,6 +34,14 @@ type LibraryBook = {
 
 const FINISHED = "buzz.bookhive.defs#finished";
 
+function bookIdentifier(book: LibraryBook): { hiveId: string } | { bookUri: string } {
+  return book.hiveId ? { hiveId: book.hiveId } : { bookUri: book.bookUri };
+}
+
+function deleteIdentifier(book: LibraryBook): { hiveId: string } | { deleteUrl: string } {
+  return book.hiveId ? { hiveId: book.hiveId } : { deleteUrl: book.deleteUrl };
+}
+
 // --- Desktop row ---
 
 const TableRow: FC<{
@@ -36,7 +51,7 @@ const TableRow: FC<{
 }> = ({ book, onUpdate, onDelete }) => (
   <tr
     className="cursor-pointer transition-[background-color] duration-150 hover:bg-muted/60 active:bg-muted/80"
-    onClick={() => (window.location.href = `/books/${book.hiveId}`)}
+    onClick={() => (window.location.href = book.bookHref)}
   >
     <td className="overflow-hidden px-4 py-2">
       <div className="flex items-center space-x-3">
@@ -58,7 +73,7 @@ const TableRow: FC<{
         status={book.status}
         onChange={(status) => {
           onUpdate({ status });
-          void updateBook(book.hiveId, { status });
+          void updateBook(bookIdentifier(book), { status });
         }}
       />
     </td>
@@ -67,7 +82,7 @@ const TableRow: FC<{
         stars={book.stars}
         onChange={(stars) => {
           onUpdate({ stars });
-          void updateBook(book.hiveId, { stars });
+          void updateBook(bookIdentifier(book), { stars });
         }}
       />
     </td>
@@ -92,7 +107,7 @@ const TableRow: FC<{
             value={book.startedAt}
             onChange={(startedAt) => {
               onUpdate({ startedAt });
-              void updateBook(book.hiveId, { startedAt });
+              void updateBook(bookIdentifier(book), { startedAt });
             }}
           />
         </div>
@@ -115,7 +130,7 @@ const TableRow: FC<{
             value={book.finishedAt}
             onChange={(finishedAt) => {
               onUpdate({ finishedAt });
-              void updateBook(book.hiveId, { finishedAt });
+              void updateBook(bookIdentifier(book), { finishedAt });
             }}
           />
         </div>
@@ -125,7 +140,7 @@ const TableRow: FC<{
       <DeleteButton
         onDelete={() => {
           onDelete();
-          void deleteBook(book.hiveId);
+          void deleteBook(deleteIdentifier(book));
         }}
       />
     </td>
@@ -141,7 +156,7 @@ const MobileCard: FC<{
 }> = ({ book, onUpdate, onDelete }) => (
   <div className="card transition-[box-shadow] duration-150 active:shadow-none">
     <div className="card-body flex gap-3">
-      <a href={`/books/${book.hiveId}`} className="flex flex-1 min-w-0 gap-3">
+      <a href={book.bookHref} className="flex flex-1 min-w-0 gap-3">
         <div className="h-16 w-12 shrink-0 overflow-hidden rounded-sm shadow-sm outline outline-1 outline-black/10 dark:outline-white/10">
           <BookCover src={book.cover || book.thumbnail} alt={`Cover of ${book.title}`} />
         </div>
@@ -162,7 +177,7 @@ const MobileCard: FC<{
           status={book.status}
           onChange={(status) => {
             onUpdate({ status });
-            void updateBook(book.hiveId, { status });
+            void updateBook(bookIdentifier(book), { status });
           }}
         />
         <div className="mt-2 grid grid-cols-2 gap-2">
@@ -191,7 +206,7 @@ const MobileCard: FC<{
               value={book.startedAt}
               onChange={(startedAt) => {
                 onUpdate({ startedAt });
-                void updateBook(book.hiveId, { startedAt });
+                void updateBook(bookIdentifier(book), { startedAt });
               }}
             />
           </div>
@@ -214,7 +229,7 @@ const MobileCard: FC<{
               value={book.finishedAt}
               onChange={(finishedAt) => {
                 onUpdate({ finishedAt });
-                void updateBook(book.hiveId, { finishedAt });
+                void updateBook(bookIdentifier(book), { finishedAt });
               }}
             />
           </div>
@@ -224,7 +239,7 @@ const MobileCard: FC<{
           className="mt-1 self-end rounded-md px-2 py-1.5 text-xs text-destructive transition-[color,background-color] duration-150 hover:bg-destructive/10 hover:text-destructive/80 focus:outline-none"
           onClick={() => {
             onDelete();
-            void deleteBook(book.hiveId);
+            void deleteBook(deleteIdentifier(book));
           }}
         >
           Remove
@@ -253,12 +268,12 @@ export const LibraryTable: FC<{ initialBooks: LibraryBook[] }> = ({ initialBooks
     });
   }, [books]);
 
-  const updateBook_ = (hiveId: string, fields: Partial<LibraryBook>) => {
-    setBooks((prev) => prev.map((b) => (b.hiveId === hiveId ? { ...b, ...fields } : b)));
+  const updateBook_ = (bookUri: string, fields: Partial<LibraryBook>) => {
+    setBooks((prev) => prev.map((b) => (b.bookUri === bookUri ? { ...b, ...fields } : b)));
   };
 
-  const deleteBook_ = (hiveId: string) => {
-    setBooks((prev) => prev.filter((b) => b.hiveId !== hiveId));
+  const deleteBook_ = (bookUri: string) => {
+    setBooks((prev) => prev.filter((b) => b.bookUri !== bookUri));
   };
 
   if (!books.length) {
@@ -313,10 +328,10 @@ export const LibraryTable: FC<{ initialBooks: LibraryBook[] }> = ({ initialBooks
           <tbody className="divide-y divide-border bg-card">
             {sortedBooks.map((book) => (
               <TableRow
-                key={book.hiveId}
+                key={book.bookUri}
                 book={book}
-                onUpdate={(fields) => updateBook_(book.hiveId, fields)}
-                onDelete={() => deleteBook_(book.hiveId)}
+                onUpdate={(fields) => updateBook_(book.bookUri, fields)}
+                onDelete={() => deleteBook_(book.bookUri)}
               />
             ))}
           </tbody>
@@ -327,10 +342,10 @@ export const LibraryTable: FC<{ initialBooks: LibraryBook[] }> = ({ initialBooks
       <div className="space-y-4 md:hidden">
         {sortedBooks.map((book) => (
           <MobileCard
-            key={book.hiveId}
+            key={book.bookUri}
             book={book}
-            onUpdate={(fields) => updateBook_(book.hiveId, fields)}
-            onDelete={() => deleteBook_(book.hiveId)}
+            onUpdate={(fields) => updateBook_(book.bookUri, fields)}
+            onDelete={() => deleteBook_(book.bookUri)}
           />
         ))}
       </div>

--- a/src/client/components/bookActions.tsx
+++ b/src/client/components/bookActions.tsx
@@ -17,19 +17,23 @@ export const STATUS_LABELS: Record<string, string> = {
 const selectClass =
   "w-full cursor-pointer rounded-md border border-border bg-card px-1.5 py-1 text-xs text-foreground shadow-sm focus:border-primary focus:ring-1 focus:ring-primary focus:outline-none";
 
-export async function updateBook(hiveId: string, fields: Record<string, unknown>) {
+export async function updateBook(
+  identifier: { hiveId: string } | { bookUri: string },
+  fields: Record<string, unknown>,
+) {
   try {
     await fetch("/api/update-book", {
       method: "POST",
       headers: { "Content-Type": "application/json", accept: "application/json" },
-      body: JSON.stringify({ hiveId, ...fields }),
+      body: JSON.stringify({ ...identifier, ...fields }),
     });
   } catch {}
 }
 
-export async function deleteBook(hiveId: string) {
+export async function deleteBook(identifier: { hiveId: string } | { deleteUrl: string }) {
   try {
-    await fetch(`/books/${hiveId}`, {
+    const url = "hiveId" in identifier ? `/books/${identifier.hiveId}` : identifier.deleteUrl;
+    await fetch(url, {
       method: "DELETE",
       headers: { accept: "application/json" },
     });

--- a/src/client/components/import/ImportTableApp.tsx
+++ b/src/client/components/import/ImportTableApp.tsx
@@ -227,7 +227,7 @@ const SuccessRow: FC<{
           status={status}
           onChange={(nextStatus) => {
             onUpdate({ status: nextStatus });
-            void updateBookApi(hiveId, { status: nextStatus });
+            void updateBookApi({ hiveId }, { status: nextStatus });
           }}
         />
       </td>
@@ -236,7 +236,7 @@ const SuccessRow: FC<{
           stars={stars}
           onChange={(rating) => {
             onUpdate({ stars: rating });
-            void updateBookApi(hiveId, { stars: rating });
+            void updateBookApi({ hiveId }, { stars: rating });
           }}
         />
       </td>
@@ -244,7 +244,7 @@ const SuccessRow: FC<{
         <DeleteButton
           onDelete={() => {
             onDelete(hiveId);
-            void deleteBookApi(hiveId);
+            void deleteBookApi({ hiveId });
           }}
         />
       </td>

--- a/src/db.ts
+++ b/src/db.ts
@@ -427,6 +427,74 @@ migrations["011"] = {
   },
 };
 
+migrations["022"] = {
+  async up(db: Kysely<unknown>) {
+    // Make user_book.hiveId nullable so foreign-lexicon records (e.g. Popfeed
+    // listItem) and unresolvable bookhive records can still be ingested. SQLite
+    // requires recreate-and-copy to drop a NOT NULL constraint.
+    // NOTE: keyed "022" so it runs last (after every column-adding migration —
+    // in particular "015" which adds user_book.previousReads, preserved below).
+    // Migrations execute in sorted-key order regardless of file position; keep
+    // the recreated column list in sync with any future user_book column adds.
+    await sql`
+      CREATE TABLE user_book_new (
+        uri TEXT PRIMARY KEY,
+        cid TEXT NOT NULL,
+        userDid TEXT NOT NULL,
+        createdAt TEXT NOT NULL,
+        indexedAt TEXT NOT NULL,
+        hiveId TEXT,
+        title TEXT NOT NULL,
+        authors TEXT NOT NULL,
+        status TEXT,
+        startedAt TEXT,
+        finishedAt TEXT,
+        stars INT8,
+        review TEXT,
+        bookProgress TEXT,
+        owned INTEGER NOT NULL DEFAULT 0,
+        previousReads TEXT
+      )
+    `.execute(db);
+    await sql`
+      INSERT INTO user_book_new (
+        uri, cid, userDid, createdAt, indexedAt, hiveId, title, authors,
+        status, startedAt, finishedAt, stars, review, bookProgress, owned,
+        previousReads
+      )
+      SELECT
+        uri, cid, userDid, createdAt, indexedAt, hiveId, title, authors,
+        status, startedAt, finishedAt, stars, review, bookProgress, owned,
+        previousReads
+      FROM user_book
+    `.execute(db);
+    await sql`DROP TABLE user_book`.execute(db);
+    await sql`ALTER TABLE user_book_new RENAME TO user_book`.execute(db);
+
+    // Recreate indexes that lived on the old table.
+    await db.schema
+      .createIndex("idx_user_book_created_at")
+      .on("user_book")
+      .column("createdAt")
+      .execute();
+    await db.schema
+      .createIndex("idx_user_book_user_did")
+      .on("user_book")
+      .column("userDid")
+      .execute();
+    await db.schema.createIndex("idx_user_book_hive_id").on("user_book").column("hiveId").execute();
+    await db.schema
+      .createIndex("idx_user_book_user_created")
+      .on("user_book")
+      .columns(["userDid", "createdAt"])
+      .execute();
+  },
+  async down(_db: Kysely<unknown>) {
+    // Not reversible: existing rows may now have NULL hiveId, which would
+    // violate the original NOT NULL constraint.
+  },
+};
+
 migrations["012"] = {
   async up(db: Kysely<unknown>) {
     // hive_book covering indexes

--- a/src/pages/components/BookCard.tsx
+++ b/src/pages/components/BookCard.tsx
@@ -17,13 +17,26 @@ export type BookCardData = {
   status?: string | null;
   stars?: number | null;
   review?: string | null;
+  /** Per-user fallback link for orphan rows (no hive_book / no hiveId). */
+  userBookHref?: string;
 };
 
-export function normalizeBookData(book: Book | HiveBook): BookCardData {
+export function normalizeBookData(
+  book: Book | HiveBook,
+  options?: { ownerHandle?: string },
+): BookCardData {
   const isUserBook = "hiveId" in book;
   const hiveId = isUserBook ? book.hiveId : book.id;
   const stars = isUserBook ? (book as Book).stars : null;
   const rating = stars != null ? stars / 2 : "rating" in book ? (book.rating || 0) / 1000 : 0;
+
+  // For user books, fall back to the user-scoped detail page when we don't
+  // have a hiveId we can navigate to canonically.
+  let userBookHref: string | undefined;
+  if (isUserBook && !hiveId && options?.ownerHandle) {
+    const rkey = (book as Book).uri.split("/").at(-1);
+    if (rkey) userBookHref = `/profile/${options.ownerHandle}/book/${rkey}`;
+  }
 
   return {
     hiveId,
@@ -35,7 +48,14 @@ export function normalizeBookData(book: Book | HiveBook): BookCardData {
     status: "status" in book ? (book as Book).status : null,
     stars,
     review: "review" in book ? (book as Book).review : null,
+    userBookHref,
   };
+}
+
+/** Resolve a clickable link for the card: hive-backed first, user-scoped fallback. */
+function bookHref(book: BookCardData): string | undefined {
+  if (book.hiveId) return `/books/${book.hiveId}`;
+  return book.userBookHref;
 }
 
 export function authorsDisplay(authors: string): string {
@@ -159,7 +179,7 @@ const DenseCard: FC<DenseProps> = ({
   tooltipPosition = "top",
   showAuthor = false,
 }) => {
-  const href = book.hiveId ? `/books/${book.hiveId}` : undefined;
+  const href = bookHref(book);
   const Tag = href ? "a" : "div";
 
   return (
@@ -218,13 +238,14 @@ type ListProps = {
 };
 
 const ListCard: FC<ListProps> = ({ book, class: className, children }) => {
+  const href = bookHref(book);
   return (
     <div class={`relative hover:z-30 ${className ?? ""}`}>
       <div class="group relative">
         <BookTooltip book={book} position="top" showChips={false} />
 
         <a
-          href={book.hiveId ? `/books/${book.hiveId}` : undefined}
+          href={href}
           class="book-cover-frame block overflow-hidden rounded-lg transition-[transform,box-shadow] duration-200 group-hover:-translate-y-1 group-hover:shadow-lg"
         >
           <div class="aspect-[2/3] w-full">
@@ -263,6 +284,7 @@ const RowCard: FC<RowProps> = ({
   children,
 }) => {
   const config = rowSizeMap[size];
+  const href = bookHref(book);
   const statusLabel =
     showStatus && book.status != null && book.status in BOOK_STATUS_MAP
       ? BOOK_STATUS_MAP[book.status as keyof typeof BOOK_STATUS_MAP]
@@ -270,12 +292,12 @@ const RowCard: FC<RowProps> = ({
 
   return (
     <div class={`flex gap-3 min-w-0 ${className ?? ""}`}>
-      <a href={book.hiveId ? `/books/${book.hiveId}` : undefined} class="shrink-0">
+      <a href={href} class="shrink-0">
         <CoverImage book={book} class={`${config.cover} rounded object-cover shrink-0`} />
       </a>
       <div class="min-w-0 flex-1 flex flex-col justify-center">
         <a
-          href={book.hiveId ? `/books/${book.hiveId}` : undefined}
+          href={href}
           class={`text-foreground hover:text-primary font-semibold ${config.titleClamp} ${config.textSize}`}
         >
           {book.title}

--- a/src/pages/components/EditableLibraryTable.tsx
+++ b/src/pages/components/EditableLibraryTable.tsx
@@ -20,7 +20,7 @@ const DateInputForm: FC<{
     >
       <input type="hidden" name="authors" value={book.authors} />
       <input type="hidden" name="title" value={book.title} />
-      <input type="hidden" name="hiveId" value={book.hiveId} />
+      <input type="hidden" name="hiveId" value={book.hiveId ?? ""} />
       {book.cover && <input type="hidden" name="coverImage" value={book.cover} />}
       {book.status && <input type="hidden" name="status" value={book.status} />}
       {book.owned ? <input type="hidden" name="owned" value="1" /> : null}
@@ -54,7 +54,7 @@ const RatingSelect: FC<{
     >
       <input type="hidden" name="authors" value={book.authors} />
       <input type="hidden" name="title" value={book.title} />
-      <input type="hidden" name="hiveId" value={book.hiveId} />
+      <input type="hidden" name="hiveId" value={book.hiveId ?? ""} />
       {book.cover && <input type="hidden" name="coverImage" value={book.cover} />}
       {book.status && <input type="hidden" name="status" value={book.status} />}
       {book.owned ? <input type="hidden" name="owned" value="1" /> : null}
@@ -98,7 +98,7 @@ const StatusSelect: FC<{
     >
       <input type="hidden" name="authors" value={book.authors} />
       <input type="hidden" name="title" value={book.title} />
-      <input type="hidden" name="hiveId" value={book.hiveId} />
+      <input type="hidden" name="hiveId" value={book.hiveId ?? ""} />
       {book.cover && <input type="hidden" name="coverImage" value={book.cover} />}
       {book.stars && <input type="hidden" name="stars" value={String(book.stars)} />}
       {book.owned ? <input type="hidden" name="owned" value="1" /> : null}

--- a/src/pages/components/book.tsx
+++ b/src/pages/components/book.tsx
@@ -10,7 +10,8 @@ const NO_BOOKS_FOUND = <p className="text-center text-lg">No books in this list<
 export const BookList: FC<{
   books?: Book[];
   fallback?: Child;
-}> = async ({ books: booksFromProps, fallback }) => {
+  ownerHandle?: string;
+}> = async ({ books: booksFromProps, fallback, ownerHandle }) => {
   const c = useRequestContext();
   const agent = await c.get("ctx").getSessionAgent();
   const books =
@@ -19,8 +20,16 @@ export const BookList: FC<{
       ? await c
           .get("ctx")
           .db.selectFrom("user_book")
-          .innerJoin("hive_book", "user_book.hiveId", "hive_book.id")
-          .selectAll()
+          .leftJoin("hive_book", "user_book.hiveId", "hive_book.id")
+          .selectAll("user_book")
+          .select([
+            "hive_book.cover",
+            "hive_book.thumbnail",
+            "hive_book.description",
+            "hive_book.rating",
+            "hive_book.ratingsCount",
+            "hive_book.meta",
+          ])
           .where("user_book.userDid", "=", agent.did)
           .orderBy("user_book.createdAt", "desc")
           .limit(10_000)
@@ -144,7 +153,7 @@ export const BookList: FC<{
         >
           <ul class="grid grid-cols-2 gap-4 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5">
             {readBooks.map((book) => (
-              <BookCard variant="dense" book={normalizeBookData(book)} />
+              <BookCard variant="dense" book={normalizeBookData(book, { ownerHandle })} />
             ))}
           </ul>
         </div>
@@ -158,7 +167,7 @@ export const BookList: FC<{
         >
           <ul class="grid grid-cols-2 gap-4 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5">
             {readingBooks.map((book) => (
-              <BookCard variant="dense" book={normalizeBookData(book)} />
+              <BookCard variant="dense" book={normalizeBookData(book, { ownerHandle })} />
             ))}
           </ul>
         </div>
@@ -172,7 +181,7 @@ export const BookList: FC<{
         >
           <ul class="grid grid-cols-2 gap-4 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5">
             {wantBooks.map((book) => (
-              <BookCard variant="dense" book={normalizeBookData(book)} />
+              <BookCard variant="dense" book={normalizeBookData(book, { ownerHandle })} />
             ))}
           </ul>
         </div>

--- a/src/pages/profile.tsx
+++ b/src/pages/profile.tsx
@@ -176,24 +176,31 @@ export const ProfilePage: FC<{
               <div
                 id="mount-library-table"
                 data-books={JSON.stringify(
-                  books.map((b) => ({
-                    hiveId: b.hiveId,
-                    title: b.title,
-                    authors: b.authors,
-                    cover: b.cover,
-                    thumbnail: b.thumbnail,
-                    status: b.status,
-                    stars: b.stars,
-                    startedAt: b.startedAt,
-                    finishedAt: b.finishedAt,
-                    createdAt: b.createdAt,
-                    owned: b.owned,
-                    review: b.review,
-                  })),
+                  books.map((b) => {
+                    const rkey = b.uri.split("/").at(-1)!;
+                    const userScopedHref = `/profile/${handle}/book/${rkey}`;
+                    return {
+                      hiveId: b.hiveId,
+                      bookUri: b.uri,
+                      bookHref: b.hiveId ? `/books/${b.hiveId}` : userScopedHref,
+                      deleteUrl: b.hiveId ? `/books/${b.hiveId}` : `${userScopedHref}/delete`,
+                      title: b.title,
+                      authors: b.authors,
+                      cover: b.cover,
+                      thumbnail: b.thumbnail,
+                      status: b.status,
+                      stars: b.stars,
+                      startedAt: b.startedAt,
+                      finishedAt: b.finishedAt,
+                      createdAt: b.createdAt,
+                      owned: b.owned,
+                      review: b.review,
+                    };
+                  }),
                 )}
               />
             ) : (
-              <BookList books={books} />
+              <BookList books={books} ownerHandle={handle} />
             )}
           </section>
 

--- a/src/pages/userBookInfo.tsx
+++ b/src/pages/userBookInfo.tsx
@@ -1,0 +1,286 @@
+import { formatDistanceToNow } from "date-fns";
+import { type FC } from "hono/jsx";
+import { BOOK_STATUS, BOOK_STATUS_MAP } from "../constants";
+import type { UserBook } from "../types";
+import { FallbackCover } from "./components/fallbackCover";
+import { Script } from "./utils/script";
+
+/**
+ * Minimum-viable book detail page for a user's PDS record that doesn't have
+ * (or can't yet resolve to) a `hive_book` row. Renders embedded title/authors
+ * from the record itself, supports status/rating/review/progress edits, and
+ * intentionally hides cross-references (genres, author links, recommendations,
+ * comments) since we have no canonical book to link them to.
+ *
+ * Mounted from /profile/:handle/book/:rkey.
+ */
+export const UserBookInfo: FC<{
+  userBook: UserBook;
+  ownerHandle: string;
+  isOwnProfile: boolean;
+}> = ({ userBook, ownerHandle, isOwnProfile }) => {
+  const rkey = userBook.uri.split("/").at(-1)!;
+  const authors = userBook.authors.split("\t");
+  const status = userBook.status ?? null;
+  const statusLabel =
+    status && status in BOOK_STATUS_MAP
+      ? BOOK_STATUS_MAP[status as keyof typeof BOOK_STATUS_MAP]
+      : status || "Want to Read";
+
+  return (
+    <div class="mx-auto max-w-4xl space-y-8">
+      {/* ===== Hero ===== */}
+      <div class="card">
+        <div class="card-body">
+          <div class="flex flex-col gap-6 md:flex-row md:gap-8">
+            <div class="mx-auto w-48 shrink-0 md:mx-0 md:w-52">
+              <FallbackCover className="aspect-2/3 w-full" />
+            </div>
+
+            <div class="flex-1">
+              <h1
+                class="mb-1 text-2xl font-bold md:text-3xl dark:text-gray-100"
+                style="text-wrap: balance"
+              >
+                {userBook.title}
+              </h1>
+              <p class="mb-3 text-lg text-muted-foreground">by {authors.join(", ")}</p>
+
+              <p class="mb-3 text-sm text-muted-foreground">
+                {`${userBook.finishedAt ? "Finished" : userBook.startedAt ? "Started" : "Added"}: ${formatDistanceToNow(
+                  userBook.finishedAt ?? userBook.startedAt ?? userBook.createdAt,
+                  { addSuffix: true },
+                )}`}
+              </p>
+
+              <p class="rounded-md bg-muted px-3 py-2 text-sm text-muted-foreground">
+                We don't have additional details for this book yet — it'll fill in once we can match
+                it to our catalog.
+              </p>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      {/* ===== Activity (owner only) ===== */}
+      {isOwnProfile && (
+        <div class="card">
+          <div class="card-body space-y-6">
+            <h2 class="text-xl font-bold text-foreground">Your Activity</h2>
+
+            <form action="/books" method="post">
+              <input type="hidden" name="bookUri" value={userBook.uri} />
+              <input type="hidden" name="title" value={userBook.title} />
+              <input type="hidden" name="authors" value={userBook.authors} />
+
+              <div class="space-y-6">
+                {/* Status */}
+                <div>
+                  <label
+                    for="user-book-status"
+                    class="mb-2 block text-sm font-semibold text-foreground"
+                  >
+                    Status
+                  </label>
+                  <select
+                    id="user-book-status"
+                    name="status"
+                    class="rounded-md border border-border bg-card px-3 py-2 text-sm text-foreground shadow-sm focus:border-primary focus:ring-1 focus:ring-primary focus:outline-none"
+                  >
+                    <option value="" selected={!status}>
+                      No status — {statusLabel}
+                    </option>
+                    {[
+                      { value: BOOK_STATUS.FINISHED, label: "Finished" },
+                      { value: BOOK_STATUS.READING, label: "Reading" },
+                      { value: BOOK_STATUS.WANTTOREAD, label: "Want to Read" },
+                      { value: BOOK_STATUS.ABANDONED, label: "Abandoned" },
+                    ].map((s) => (
+                      <option key={s.value} value={s.value} selected={status === s.value}>
+                        {s.label}
+                      </option>
+                    ))}
+                  </select>
+                </div>
+
+                {/* Owned */}
+                <div class="flex items-center gap-2">
+                  <input
+                    type="checkbox"
+                    id="user-book-owned"
+                    name="owned"
+                    value="true"
+                    checked={Boolean(userBook.owned)}
+                    class="h-4 w-4 rounded border border-border text-primary focus:ring-primary"
+                  />
+                  <label for="user-book-owned" class="text-sm text-foreground">
+                    I own this book
+                  </label>
+                </div>
+
+                {/* Rating */}
+                <div>
+                  <label
+                    for="user-book-stars"
+                    class="mb-2 block text-sm font-semibold text-foreground"
+                  >
+                    Rating (out of 10)
+                  </label>
+                  <input
+                    type="number"
+                    id="user-book-stars"
+                    name="stars"
+                    min={0}
+                    max={10}
+                    step={1}
+                    value={userBook.stars ?? ""}
+                    class="w-24 rounded-md border border-border bg-card px-2 py-1.5 text-sm text-foreground shadow-sm focus:border-primary focus:ring-1 focus:ring-primary focus:outline-none"
+                  />
+                </div>
+
+                {/* Review */}
+                <div>
+                  <label
+                    for="user-book-review"
+                    class="mb-2 block text-sm font-semibold text-foreground"
+                  >
+                    Review
+                  </label>
+                  <textarea
+                    id="user-book-review"
+                    name="review"
+                    rows={4}
+                    placeholder="What did you think?"
+                    class="w-full rounded-md border border-border bg-card px-3 py-2 text-sm text-foreground shadow-sm focus:border-primary focus:ring-1 focus:ring-primary focus:outline-none"
+                  >
+                    {userBook.review || ""}
+                  </textarea>
+                </div>
+
+                {/* Reading dates */}
+                <div class="flex flex-wrap items-center gap-4">
+                  <div class="flex items-center gap-2">
+                    <label class="text-sm font-semibold text-foreground" for="user-book-started">
+                      Started
+                    </label>
+                    <input
+                      type="date"
+                      id="user-book-started"
+                      name="startedAt"
+                      value={
+                        userBook.startedAt
+                          ? new Date(userBook.startedAt).toISOString().slice(0, 10)
+                          : ""
+                      }
+                      class="rounded-md border border-border bg-card px-2 py-1.5 text-sm text-foreground shadow-sm focus:border-primary focus:ring-1 focus:ring-primary focus:outline-none"
+                    />
+                  </div>
+                  <div class="flex items-center gap-2">
+                    <label class="text-sm font-semibold text-foreground" for="user-book-finished">
+                      Finished
+                    </label>
+                    <input
+                      type="date"
+                      id="user-book-finished"
+                      name="finishedAt"
+                      value={
+                        userBook.finishedAt
+                          ? new Date(userBook.finishedAt).toISOString().slice(0, 10)
+                          : ""
+                      }
+                      class="rounded-md border border-border bg-card px-2 py-1.5 text-sm text-foreground shadow-sm focus:border-primary focus:ring-1 focus:ring-primary focus:outline-none"
+                    />
+                  </div>
+                </div>
+
+                {/* Reading progress */}
+                <div>
+                  <label class="mb-2 block text-sm font-semibold text-foreground">
+                    Reading Progress
+                  </label>
+                  <div class="flex items-center gap-2">
+                    <label class="text-sm text-muted-foreground" for="user-book-current-page">
+                      Page
+                    </label>
+                    <input
+                      type="number"
+                      id="user-book-current-page"
+                      name="currentPage"
+                      value={userBook.bookProgress?.currentPage ?? ""}
+                      min={0}
+                      class="w-24 rounded-md border border-border bg-card px-2 py-1.5 text-sm text-foreground shadow-sm focus:border-primary focus:ring-1 focus:ring-primary focus:outline-none"
+                    />
+                    <span class="text-muted-foreground">/</span>
+                    <input
+                      type="number"
+                      id="user-book-total-page"
+                      name="totalPages"
+                      value={userBook.bookProgress?.totalPages ?? ""}
+                      min={1}
+                      class="w-24 rounded-md border border-border bg-card px-2 py-1.5 text-sm text-foreground shadow-sm focus:border-primary focus:ring-1 focus:ring-primary focus:outline-none"
+                      placeholder="Total"
+                    />
+                  </div>
+                </div>
+
+                <button
+                  type="submit"
+                  class="btn btn-primary w-full transition-[scale] duration-150 active:scale-[0.96] sm:w-auto"
+                >
+                  Save
+                </button>
+              </div>
+            </form>
+
+            {/* Delete */}
+            <div class="border-t border-border pt-4">
+              <button
+                type="button"
+                id="delete-user-book-btn"
+                class="min-h-[40px] inline-flex cursor-pointer items-center text-xs text-muted-foreground hover:text-destructive"
+              >
+                Remove from library
+              </button>
+              <dialog
+                id="delete-user-book-dialog"
+                class="fixed top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 rounded-lg border border-border bg-card p-6 text-card-foreground shadow-lg backdrop:bg-black/50"
+              >
+                <h3 class="mb-2 text-lg font-semibold">Remove book?</h3>
+                <p class="mb-4 text-sm text-muted-foreground">
+                  This will remove "{userBook.title}" from your library. This cannot be undone.
+                </p>
+                <div class="flex justify-end gap-2">
+                  <button
+                    type="button"
+                    class="btn btn-ghost"
+                    onclick="this.closest('dialog').close()"
+                  >
+                    Cancel
+                  </button>
+                  <form
+                    action={`/profile/${ownerHandle}/book/${rkey}/delete`}
+                    method="post"
+                    class="inline"
+                  >
+                    <button type="submit" class="btn btn-destructive">
+                      Remove
+                    </button>
+                  </form>
+                </div>
+              </dialog>
+              <Script
+                script={(document) => {
+                  const btn = document.getElementById("delete-user-book-btn");
+                  const dialog = document.getElementById(
+                    "delete-user-book-dialog",
+                  ) as HTMLDialogElement;
+                  btn?.addEventListener("click", () => dialog?.showModal());
+                }}
+              />
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+};

--- a/src/routes/api.tsx
+++ b/src/routes/api.tsx
@@ -40,7 +40,8 @@ function dateInputToISO(val: string): string {
 }
 
 const updateBookSchema = z.object({
-  hiveId: z.string(),
+  hiveId: z.string().optional(),
+  bookUri: z.string().optional(),
   status: z.optional(z.string()),
   owned: z.optional(z.boolean()),
   review: z.optional(z.string()),
@@ -91,7 +92,7 @@ const app = new Hono<AppEnv>()
       return c.json({ success: false, message: "Invalid Session" }, 401);
     }
     const payload = c.req.valid("json");
-    const { hiveId, bookProgress, ...updates } = payload;
+    const { hiveId, bookUri, bookProgress, ...updates } = payload;
 
     let normalizedProgress: BookProgress | undefined | null = bookProgress as
       | BookProgress
@@ -123,23 +124,26 @@ const app = new Hono<AppEnv>()
         updates.status = BOOK_STATUS.READING;
       }
     }
-    if (!hiveId) {
-      return c.json({ success: false, message: "Invalid ID" }, 400);
+    if (!hiveId && !bookUri) {
+      return c.json({ success: false, message: "Provide hiveId or bookUri" }, 400);
     }
+    const lockToken = hiveId ?? bookUri!;
     const bookLockKey = "book_lock:" + agent.did;
     try {
-      await c.get("ctx").kv.setItem(bookLockKey, hiveId);
+      await c.get("ctx").kv.setItem(bookLockKey, lockToken);
       startTime(c, "pds_update_book");
       await updateBookRecord({
         ctx: c.get("ctx"),
         agent,
-        hiveId: hiveId as HiveId,
+        hiveId: hiveId ? (hiveId as HiveId) : undefined,
+        bookUri,
         updates,
       });
       endTime(c, "pds_update_book");
       c.get("ctx").addWideEventContext({
         api: "update_book",
         hiveId,
+        bookUri,
         userDid: agent.did,
       });
       return c.json({ success: true, message: "Book updated" });
@@ -147,6 +151,7 @@ const app = new Hono<AppEnv>()
       c.get("ctx").addWideEventContext({
         api_update_book: "failed",
         hiveId,
+        bookUri,
         userDid: agent.did,
         error: (e as Error).message,
       });

--- a/src/routes/books.tsx
+++ b/src/routes/books.tsx
@@ -231,7 +231,8 @@ const app = new Hono<AppEnv>()
       z.object({
         authors: z.string(),
         title: z.string(),
-        hiveId: z.string(),
+        hiveId: z.string().optional(),
+        bookUri: z.string().optional(),
         status: z.string().optional(),
         coverImage: z.string().optional(),
         startedAt: z.string().optional(),
@@ -284,6 +285,7 @@ const app = new Hono<AppEnv>()
           status,
           owned,
           hiveId,
+          bookUri,
           coverImage,
           startedAt,
           finishedAt,
@@ -295,6 +297,18 @@ const app = new Hono<AppEnv>()
           totalChapters,
           percent,
         } = c.req.valid("form");
+
+        if (!hiveId && !bookUri) {
+          c.status(400);
+          return c.render(
+            <ErrorPage
+              message="Missing book identifier"
+              description="Either hiveId or bookUri is required."
+              statusCode={400}
+            />,
+            { title: "Bad Request" },
+          );
+        }
 
         let bookProgress: Record<string, unknown> | undefined;
         if (currentPage || totalPages || currentChapter || totalChapters || percent !== undefined) {
@@ -339,18 +353,19 @@ const app = new Hono<AppEnv>()
         }
 
         try {
-          await c.get("ctx").kv.setItem(bookLockKey, hiveId);
+          await c.get("ctx").kv.setItem(bookLockKey, hiveId ?? bookUri!);
           startTime(c, "pds_update_book");
           await updateBookRecord({
             ctx: c.get("ctx"),
             agent,
-            hiveId: hiveId as HiveId,
+            hiveId: hiveId ? (hiveId as HiveId) : undefined,
+            bookUri,
             updates: {
               authors,
               title,
               status,
               owned,
-              hiveId,
+              ...(hiveId ? { hiveId } : {}),
               coverImage,
               startedAt,
               finishedAt,
@@ -375,7 +390,15 @@ const app = new Hono<AppEnv>()
         } finally {
           await c.get("ctx").kv.del(bookLockKey);
         }
-        const redirectTo = c.req.query("redirect") || `/books/${hiveId}`;
+        let defaultRedirect: string;
+        if (hiveId) {
+          defaultRedirect = `/books/${hiveId}`;
+        } else {
+          const handle = (await c.get("ctx").resolver.resolveDidToHandle(agent.did)) ?? agent.did;
+          const rkey = bookUri!.split("/").at(-1)!;
+          defaultRedirect = `/profile/${handle}/book/${rkey}`;
+        }
+        const redirectTo = c.req.query("redirect") || defaultRedirect;
         return c.redirect(redirectTo);
       } catch (err) {
         c.set("requestError", err);

--- a/src/routes/main.tsx
+++ b/src/routes/main.tsx
@@ -8,6 +8,7 @@ import { endTime, startTime, timing } from "hono/timing";
 import { Hono } from "hono";
 
 import type { AppDeps, AppEnv, HonoServer } from "../context";
+import type { HiveId } from "../types";
 import { BookFields } from "../db";
 import { createContextMiddleware } from "../context";
 import { loginRouter } from "../auth/router";
@@ -30,7 +31,6 @@ import {
   proxyImageResponse,
   queryToModifiers,
 } from "../utils/imageProxy";
-import type { HiveId } from "../types";
 import { createXrpcRouter } from "../xrpc/router";
 import {
   searchBooks,
@@ -221,9 +221,13 @@ export function mainRouter(deps: AppDeps): HonoServer {
             .selectFrom("user_book")
             .leftJoin("hive_book", "user_book.hiveId", "hive_book.id")
             .select(BookFields)
+            .where("user_book.hiveId", "is not", null)
             .orderBy("user_book.createdAt", "desc")
             .limit(10)
-            .execute(),
+            .execute()
+            .then((rows) =>
+              rows.filter((r): r is typeof r & { hiveId: HiveId } => r.hiveId !== null),
+            ),
         ]);
         endTime(c, "marketing_trending");
         endTime(c, "marketing_recent");

--- a/src/routes/profile.tsx
+++ b/src/routes/profile.tsx
@@ -10,9 +10,11 @@ import { endTime, startTime } from "hono/timing";
 import { sql } from "kysely";
 import type { AppEnv } from "../context";
 import { BookFields } from "../db";
+import { ids } from "../bsky/lexicon";
 import { Error as ErrorPage } from "../pages/error";
 import { ProfilePage } from "../pages/profile";
 import { ReadingStatsPage } from "../pages/readingStats";
+import { UserBookInfo } from "../pages/userBookInfo";
 import { getProfile, getProfiles } from "../utils/getProfile";
 import { hydrateUserBook } from "../utils/bookProgress";
 import {
@@ -250,6 +252,119 @@ const app = new Hono<AppEnv>()
         image: `${new URL(c.req.url).origin}/og/profile/${handle}/stats/${year}`,
       },
     );
+  })
+  .get("/profile/:handle/book/:rkey", async (c) => {
+    const handle = c.req.param("handle");
+    const rkey = c.req.param("rkey");
+
+    startTime(c, "resolveDid");
+    const did = isDid(handle) ? handle : await c.get("ctx").baseIdResolver.handle.resolve(handle);
+    endTime(c, "resolveDid");
+
+    if (!did) {
+      c.status(404);
+      return c.render(
+        <ErrorPage
+          message="Profile not found"
+          description="This profile does not exist or has no books on BookHive."
+          statusCode={404}
+        />,
+        { title: "Profile Not Found" },
+      );
+    }
+
+    const uri = `at://${did}/${ids.BuzzBookhiveBook}/${rkey}`;
+    const rawUserBook = await c
+      .get("ctx")
+      .db.selectFrom("user_book")
+      .selectAll()
+      .where("uri", "=", uri)
+      .executeTakeFirst();
+
+    if (!rawUserBook) {
+      c.status(404);
+      return c.render(
+        <ErrorPage
+          message="Book not found"
+          description="This book is not in this user's library."
+          statusCode={404}
+        />,
+        { title: "Book Not Found" },
+      );
+    }
+
+    // Prefer the canonical /books/:hiveId page when we have one — it has full
+    // metadata, comments, recommendations, etc.
+    if (rawUserBook.hiveId) {
+      const hiveBook = await c
+        .get("ctx")
+        .db.selectFrom("hive_book")
+        .select("id")
+        .where("id", "=", rawUserBook.hiveId)
+        .executeTakeFirst();
+      if (hiveBook) {
+        return c.redirect(`/books/${rawUserBook.hiveId}`);
+      }
+    }
+
+    const sessionAgent = await c.get("ctx").getSessionAgent();
+    const userBook = hydrateUserBook(rawUserBook);
+
+    return c.render(
+      <UserBookInfo
+        userBook={userBook}
+        ownerHandle={handle}
+        isOwnProfile={sessionAgent?.did === did}
+      />,
+      {
+        title: `BookHive | ${userBook.title}`,
+        description: `${userBook.title} by ${userBook.authors.split("\t").join(", ")} — @${handle}'s library on BookHive`,
+      },
+    );
+  })
+  .post("/profile/:handle/book/:rkey/delete", async (c) => {
+    const agent = await c.get("ctx").getSessionAgent();
+    if (!agent) {
+      c.status(401);
+      return c.render(
+        <ErrorPage
+          message="Invalid Session"
+          description="Login to delete a book"
+          statusCode={401}
+        />,
+        { title: "Unauthorized" },
+      );
+    }
+    const handle = c.req.param("handle");
+    const rkey = c.req.param("rkey");
+    const did = isDid(handle) ? handle : await c.get("ctx").baseIdResolver.handle.resolve(handle);
+    if (!did || did !== agent.did) {
+      c.status(403);
+      return c.render(
+        <ErrorPage
+          message="Forbidden"
+          description="You can only delete books from your own library."
+          statusCode={403}
+        />,
+        { title: "Forbidden" },
+      );
+    }
+
+    const uri = `at://${did}/${ids.BuzzBookhiveBook}/${rkey}`;
+    await agent.post("com.atproto.repo.deleteRecord", {
+      input: { repo: agent.did, collection: ids.BuzzBookhiveBook, rkey },
+    });
+    await c
+      .get("ctx")
+      .db.deleteFrom("user_book")
+      .where("userDid", "=", agent.did)
+      .where("uri", "=", uri)
+      .execute();
+
+    if (c.req.header("accept") === "application/json") {
+      return c.json({ success: true, uri });
+    }
+    return c.redirect(`/profile/${handle}`);
   })
   .get("/profile/:handle", async (c) => {
     const handle = c.req.param("handle");

--- a/src/routes/rss.ts
+++ b/src/routes/rss.ts
@@ -127,7 +127,9 @@ const app = new Hono<AppEnv>()
       query = query.where("user_book.status", "in", statusFilter) as typeof query;
     }
 
-    const rows = await query.execute();
+    const rows = (await query.execute()).filter(
+      (r): r is typeof r & { hiveId: HiveId } => r.hiveId !== null,
+    );
 
     const handle = isDid(handleParam)
       ? ((await ctx.resolver.resolveDidToHandle(did)) ?? handleParam)
@@ -259,7 +261,9 @@ ${itemsXml}
       query = query.where("user_book.status", "in", statusFilter) as typeof query;
     }
 
-    const rows = await query.execute();
+    const rows = (await query.execute()).filter(
+      (r): r is typeof r & { hiveId: HiveId } => r.hiveId !== null,
+    );
 
     const handle = isDid(handleParam)
       ? ((await ctx.resolver.resolveDidToHandle(did)) ?? handleParam)

--- a/src/types.ts
+++ b/src/types.ts
@@ -53,9 +53,10 @@ export type UserBook = {
    */
   cid: string;
   /**
-   * Hive ID of the book
+   * Hive ID of the book. Null when the record came from a foreign lexicon
+   * (e.g. Popfeed) or when our hive_book lookup is still pending.
    */
-  hiveId: HiveId;
+  hiveId: HiveId | null;
   /**
    * DID of the user who added the book
    */

--- a/src/utils/getBook.ts
+++ b/src/utils/getBook.ts
@@ -194,22 +194,44 @@ export async function getBookRecord({
 }
 
 /**
- * Update a book in the user's PDS
+ * Update a book in the user's PDS.
+ *
+ * Identify the target by either `hiveId` (canonical / hive-backed books) or
+ * `bookUri` (user-scoped, useful when no `hive_book` row exists yet — see
+ * `/profile/:handle/book/:rkey`). Exactly one is required.
  */
 export async function updateBookRecord({
   ctx,
   agent,
   hiveId,
+  bookUri,
   updates,
   skipAutoDate = false,
 }: {
   ctx: BookUtilContext;
   agent: SessionClient;
-  hiveId: HiveId;
+  hiveId?: HiveId;
+  bookUri?: string;
   updates: Partial<BookRecord.Record> & { coverImage?: string };
   skipAutoDate?: boolean;
 }): Promise<{ book: BookRecord.Record; userBook: UserBook }> {
-  const userBook = await getUserBook({ ctx, agent, hiveId });
+  if (!hiveId && !bookUri) {
+    throw new Error("updateBookRecord requires either hiveId or bookUri");
+  }
+
+  let userBook: UserBook | null = null;
+  if (bookUri) {
+    const row = await ctx.db
+      .selectFrom("user_book")
+      .selectAll()
+      .where("uri", "=", bookUri)
+      .where("userDid", "=", agent.did)
+      .executeTakeFirst();
+    if (!row) throw new Error("Book not found in your library");
+    userBook = hydrateUserBook(row);
+  } else {
+    userBook = await getUserBook({ ctx, agent, hiveId: hiveId! });
+  }
 
   let originalBook: BookRecord.Record | null = null;
   if (userBook) {
@@ -220,11 +242,20 @@ export async function updateBookRecord({
     });
   }
 
+  // The PDS record is the source of truth for hiveId on uri-based updates,
+  // since we may not have it in our DB (orphan rows), and the lexicon
+  // guarantees the field is always present.
+  const effectiveHiveId =
+    hiveId ?? (originalBook?.hiveId as HiveId | undefined) ?? userBook?.hiveId ?? null;
+  if (!effectiveHiveId) {
+    throw new Error("Could not resolve hiveId for book update");
+  }
+
   if (!originalBook && !userBook) {
     const hiveBook = await ctx.db
       .selectFrom("hive_book")
       .selectAll()
-      .where("id", "=", hiveId)
+      .where("id", "=", effectiveHiveId)
       .executeTakeFirst();
     if (hiveBook) {
       Object.assign(updates, {
@@ -287,20 +318,22 @@ export async function updateBookRecord({
   // Determine the final status (use auto-inferred status or original status)
   const finalStatus = autoStatus || originalBook?.status;
 
-  const identifiersRow = await findBookIdentifiersByLookup({ ctx, hiveId });
+  const identifiersRow = await findBookIdentifiersByLookup({ ctx, hiveId: effectiveHiveId });
   const identifiers = toBookIdentifiersOutput(identifiersRow);
 
   // Ensure the book is cataloged before writing to the user's PDS so we can embed
   // hiveBookUri. Fast path (expected): already cataloged, one DB read, no network.
   // Slow path (last resort): enrich + catalog with timeouts if it slipped through.
-  const hiveBookAtUri = await ensureBookCataloged(ctx, hiveId);
+  // For orphan rows (no hive_book), this returns undefined and we just preserve
+  // whatever hiveBookUri was already on the PDS record.
+  const hiveBookAtUri = await ensureBookCataloged(ctx, effectiveHiveId);
 
   const bookData = {
     $type: ids.BuzzBookhiveBook,
     // Always prefer original values
     title: originalBook?.title || updates.title,
     authors: originalBook?.authors || updates.authors,
-    hiveId: originalBook?.hiveId || hiveId,
+    hiveId: originalBook?.hiveId || effectiveHiveId,
     createdAt: originalBook?.createdAt || new Date().toISOString(),
     cover: originalBook?.cover || (await uploadImageBlob(updates.coverImage, agent, 800)),
     // Always prefer new values (including auto-inferred status)

--- a/src/xrpc/router.ts
+++ b/src/xrpc/router.ts
@@ -696,7 +696,8 @@ export function createXrpcRouter<E extends XrpcContext, V extends { ctx: E } = {
         .where("hiveId", "==", book.id)
         .orderBy("indexedAt", "desc")
         .limit(100)
-        .execute();
+        .execute()
+        .then((rows) => rows.filter((b): b is typeof b & { hiveId: HiveId } => b.hiveId !== null));
 
       const didToHandle = await ctx.resolver.resolveDidsToHandles(
         Array.from(
@@ -824,11 +825,19 @@ export function createXrpcRouter<E extends XrpcContext, V extends { ctx: E } = {
         .orderBy("user_book.createdAt", "desc")
         .limit(50)
         .execute();
+      // hiveId is now optional in the userBook lexicon: orphan rows (foreign
+      // lexicons / unresolved catalog) flow through with hiveId === null.
+      // Clients use `uri` for stable identity and skip canonical navigation
+      // when hiveId is missing.
       const parsedBooks = books.map((book) => hydrateUserBook(book));
       const parsedFriendsBuzzes = friendsBuzzes.map((book) => hydrateUserBook(book));
 
       const profileHiveIds = [
-        ...new Set([...books.map((b) => b.hiveId), ...friendsBuzzes.map((b) => b.hiveId)]),
+        ...new Set(
+          [...parsedBooks, ...parsedFriendsBuzzes]
+            .map((b) => b.hiveId)
+            .filter((id): id is HiveId => id !== null),
+        ),
       ];
       const profileIdRows =
         profileHiveIds.length > 0
@@ -883,7 +892,8 @@ export function createXrpcRouter<E extends XrpcContext, V extends { ctx: E } = {
           userHandle: didToHandle[b.userDid] ?? b.userDid,
           authors: b.authors,
           createdAt: b.createdAt,
-          hiveId: b.hiveId,
+          hiveId: b.hiveId ?? undefined,
+          uri: b.uri,
           title: b.title,
           thumbnail: b.thumbnail || "",
           cover: b.cover ?? b.thumbnail ?? undefined,
@@ -897,15 +907,16 @@ export function createXrpcRouter<E extends XrpcContext, V extends { ctx: E } = {
           startedAt: b.startedAt ?? undefined,
           bookProgress: b.bookProgress ?? undefined,
           previousReads: b.previousReads ?? undefined,
-          identifiers: identifiersByHiveId.get(b.hiveId),
-          genres: genresByHiveId.get(b.hiveId as HiveId),
+          identifiers: b.hiveId ? identifiersByHiveId.get(b.hiveId) : undefined,
+          genres: b.hiveId ? genresByHiveId.get(b.hiveId) : undefined,
         })),
         books: parsedBooks.map((b) => ({
           userDid: b.userDid,
           userHandle: didToHandle[b.userDid] ?? b.userDid,
           authors: b.authors,
           createdAt: b.createdAt,
-          hiveId: b.hiveId,
+          hiveId: b.hiveId ?? undefined,
+          uri: b.uri,
           title: b.title,
           thumbnail: b.thumbnail || "",
           cover: b.cover ?? b.thumbnail ?? undefined,
@@ -919,13 +930,15 @@ export function createXrpcRouter<E extends XrpcContext, V extends { ctx: E } = {
           startedAt: b.startedAt ?? undefined,
           bookProgress: b.bookProgress ?? undefined,
           previousReads: b.previousReads ?? undefined,
-          identifiers: identifiersByHiveId.get(b.hiveId),
-          genres: genresByHiveId.get(b.hiveId as HiveId),
+          identifiers: b.hiveId ? identifiersByHiveId.get(b.hiveId) : undefined,
+          genres: b.hiveId ? genresByHiveId.get(b.hiveId) : undefined,
         })),
-        activity: books
+        activity: parsedBooks
           .reduce(
             (acc, b) => {
-              const existing = acc.find((a) => a.hiveId === b.hiveId);
+              // Dedupe by uri (always unique) so orphan rows aren't collapsed
+              // together when hiveId is null on multiple rows.
+              const existing = acc.find((a) => a.uri === b.uri);
               if (!existing || new Date(b.createdAt) > new Date(existing.createdAt)) {
                 if (existing) {
                   acc.splice(acc.indexOf(existing), 1);
@@ -940,7 +953,8 @@ export function createXrpcRouter<E extends XrpcContext, V extends { ctx: E } = {
                         ? "review"
                         : "started",
                   createdAt: b.createdAt,
-                  hiveId: b.hiveId,
+                  hiveId: b.hiveId ?? undefined,
+                  uri: b.uri,
                   title: b.title,
                   userDid: b.userDid,
                   userHandle: didToHandle[b.userDid] ?? b.userDid,
@@ -951,7 +965,8 @@ export function createXrpcRouter<E extends XrpcContext, V extends { ctx: E } = {
             [] as Array<{
               type: string;
               createdAt: string;
-              hiveId: string;
+              hiveId?: string;
+              uri: string;
               title: string;
               userDid: string;
               userHandle: string;
@@ -1058,6 +1073,8 @@ export function createXrpcRouter<E extends XrpcContext, V extends { ctx: E } = {
 
       const rows = await query.execute();
       const hasMore = rows.length > limit;
+      // hiveId is now optional in feedActivity; orphan rows flow through with
+      // hiveId omitted. Clients use `uri` as the stable key.
       const activities = rows.slice(0, limit);
 
       const allDids = [...new Set(activities.map((a) => a.userDid))];
@@ -1068,7 +1085,8 @@ export function createXrpcRouter<E extends XrpcContext, V extends { ctx: E } = {
         activities: activities.map((a) => ({
           userDid: a.userDid,
           userHandle: didToHandle[a.userDid] ?? a.userDid,
-          hiveId: a.hiveId,
+          hiveId: a.hiveId ?? undefined,
+          uri: a.uri,
           title: a.title,
           authors: a.authors,
           status: a.status ?? undefined,
@@ -1185,7 +1203,11 @@ export function createXrpcRouter<E extends XrpcContext, V extends { ctx: E } = {
         .orderBy("user_book.indexedAt", "desc")
         .limit(10_000)
         .execute();
-      const parsedBooks = books.map((b) => hydrateUserBook(b));
+      // Stats only include books we can resolve via hiveId; orphan rows have no
+      // page count / genre data so they'd skew or error in the stats pipeline.
+      const parsedBooks = books
+        .map((b) => hydrateUserBook(b))
+        .filter((b): b is typeof b & { hiveId: HiveId } => b.hiveId !== null);
 
       const finishedInYear = filterFinishedBooksByYear(parsedBooks, year);
 
@@ -1220,7 +1242,7 @@ export function createXrpcRouter<E extends XrpcContext, V extends { ctx: E } = {
 
       const toBookSummary = (
         b: {
-          hiveId: string;
+          hiveId: string | null;
           title: string;
           authors: string;
           cover?: string | null;
@@ -1229,7 +1251,7 @@ export function createXrpcRouter<E extends XrpcContext, V extends { ctx: E } = {
           rating?: number | null;
         } | null,
       ) => {
-        if (!b) return undefined;
+        if (!b || !b.hiveId) return undefined;
         return {
           hiveId: b.hiveId,
           title: b.title,


### PR DESCRIPTION
Books whose `hiveId` the catalog hasn't matched (and future foreign-lexicon imports like Popfeed) were silently dropped by the ingester and invisible in the UI; this makes those "orphan" books displayable and manageable from a new user-scoped page. The ingester now inserts every valid `buzz.bookhive.book` record regardless of whether a `hive_book` row exists, `user_book.hiveId` becomes nullable (migration `022`, a recreate-and-copy verified against a 60k-row DB copy to preserve all data including the `previousReads` column), and `activity`/`userBook`/`feedActivity` gain a stable `uri`. A new `GET/POST /profile/:handle/book/:rkey` route with a minimal `UserBookInfo` page manages status/rating/review/progress via `bookUri`, and the add/update/delete APIs, profile shelves, cards, and library table now left-join `hive_book` and link orphan rows to that page. XRPC, RSS, and the feed emit `uri` and tolerate a null `hiveId`, and the iOS feed/profile/library/status screens key by `uri` and gate book navigation on `hiveId`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for books that are not yet matched to the catalog.
  * Unresolved books remain visible in libraries, feeds, profiles, and activity lists.
  * Added detail pages for uncataloged books, including editing and deletion for owners.
  * Book updates and removal now work through either catalog links or record links.

* **Bug Fixes**
  * Improved list stability and duplicate prevention.
  * Disabled unavailable navigation instead of linking to missing book details.
  * Excluded unresolved books from catalog-dependent statistics and feeds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->