### PR TITLE
fix: bridge KOSync progress to public book via personal_book fallback

### DIFF
--- a/src/routes/admin.ts
+++ b/src/routes/admin.ts
@@ -44,7 +44,7 @@ const admin = new Hono<AppEnv>()
     ctx.addWideEventContext({ backfill_catalog: "started" });
     return c.json({ message: "Backfill started" }, 202);
   })
-  .get("/backfill-catalog/progress", (c) => {
+  .get("/backfill-catalog/progress", async (c) => {
     const authorization = c.req.header("authorization");
     if (
       !env.EXPORT_SHARED_SECRET ||
@@ -56,7 +56,8 @@ const admin = new Hono<AppEnv>()
       return c.json({ message: "Not Found" }, 404);
     }
 
-    return c.json(getBackfillProgress());
+    const ctx = c.get("ctx");
+    return c.json(await getBackfillProgress(ctx.kv));
   })
   .get("/export", async (c) => {
     const ctx = c.get("ctx");

--- a/src/routes/library.tsx
+++ b/src/routes/library.tsx
@@ -23,7 +23,7 @@ import {
   streamPersonalBook,
   MAX_PERSONAL_BOOK_BYTES,
 } from "../utils/personalLibrary";
-import { NO_HIVE_MATCH } from "../utils/syncMatching";
+import { NO_HIVE_MATCH, matchSyncDocument } from "../utils/syncMatching";
 import type { HiveId, SyncProgressData } from "../types";
 
 const MAX_FILE_SIZE = MAX_PERSONAL_BOOK_BYTES;
@@ -151,6 +151,14 @@ const app = new Hono<AppEnv>()
         matchedHiveId = syncDoc.hiveId;
       }
 
+      if (!matchedHiveId) {
+        matchedHiveId = await matchSyncDocument(db, {
+          title: metadata.title,
+          authors: metadata.authors,
+          filename: file.name,
+        });
+      }
+
       const now = new Date().toISOString();
       await db
         .insertInto("personal_book")
@@ -173,8 +181,15 @@ const app = new Hono<AppEnv>()
         })
         .execute();
 
-      // Mark the book as owned if auto-linked and user has it in their library
       if (matchedHiveId) {
+        await db
+          .updateTable("sync_document")
+          .set({ hiveId: matchedHiveId })
+          .where("userDid", "=", agent.did)
+          .where("documentHash", "=", contentHash)
+          .where("hiveId", "is", null)
+          .execute();
+
         await db
           .updateTable("user_book")
           .set({ owned: 1 })

--- a/src/routes/sync/kosync.ts
+++ b/src/routes/sync/kosync.ts
@@ -103,15 +103,27 @@ app.put("/syncs/progress", syncAuthMiddleware, async (c) => {
 
   if (!hiveId && (title || authors)) {
     hiveId = await matchSyncDocument(db, { title, authors, filename });
-    if (hiveId) {
-      await db
-        .updateTable("sync_document")
-        .set({ hiveId })
-        .where("userDid", "=", userDid)
-        .where("provider", "=", "kosync")
-        .where("documentHash", "=", document)
-        .execute();
-    }
+  }
+
+  if (!hiveId) {
+    const pb = await db
+      .selectFrom("personal_book")
+      .select("hiveId")
+      .where("userDid", "=", userDid)
+      .where("contentHash", "=", document)
+      .executeTakeFirst();
+    if (pb?.hiveId) hiveId = pb.hiveId;
+  }
+
+  if (hiveId) {
+    await db
+      .updateTable("sync_document")
+      .set({ hiveId })
+      .where("userDid", "=", userDid)
+      .where("provider", "=", "kosync")
+      .where("documentHash", "=", document)
+      .where("hiveId", "is", null)
+      .execute();
   }
 
   if (hiveId) {

--- a/src/utils/catalogBookService.ts
+++ b/src/utils/catalogBookService.ts
@@ -2,6 +2,7 @@ import { Client } from "@atcute/client";
 import { PasswordSession } from "@atcute/password-session";
 import type { ActorIdentifier } from "@atcute/lexicons/syntax";
 import type { Logger } from "pino";
+import type { Storage } from "unstorage";
 import type { SessionClient } from "../auth/client";
 import type { AppContext } from "../context";
 import { createActorResolver } from "../bsky/id-resolver";
@@ -39,6 +40,7 @@ export async function createServiceAccountAgent(
 
 type CatalogCtx = Pick<AppContext, "db"> & {
   serviceAccountAgent: AppContext["serviceAccountAgent"] | undefined;
+  kv?: Storage;
   logger?: Logger;
 };
 
@@ -234,7 +236,7 @@ class RateLimitError extends Error {
 }
 
 export interface BackfillProgress {
-  status: "idle" | "running" | "completed" | "failed";
+  status: "idle" | "running" | "completed" | "failed" | "interrupted";
   startedAt: string | null;
   completedAt: string | null;
   written: number;
@@ -243,6 +245,8 @@ export interface BackfillProgress {
   lastBatchAt: string | null;
   error: string | null;
 }
+
+const BACKFILL_KV_KEY = "backfill:catalog_progress";
 
 let backfillProgress: BackfillProgress = {
   status: "idle",
@@ -255,8 +259,27 @@ let backfillProgress: BackfillProgress = {
   error: null,
 };
 
-export function getBackfillProgress(): BackfillProgress {
-  return { ...backfillProgress };
+function persistProgress(kv: Storage | undefined) {
+  if (!kv) return;
+  kv.setItem(BACKFILL_KV_KEY, JSON.stringify(backfillProgress)).catch(() => {});
+}
+
+export async function getBackfillProgress(kv?: Storage): Promise<BackfillProgress> {
+  if (backfillProgress.status !== "idle") return { ...backfillProgress };
+  if (!kv) return { ...backfillProgress };
+  const stored = await kv.getItem<string>(BACKFILL_KV_KEY);
+  if (!stored) return { ...backfillProgress };
+  try {
+    const parsed = JSON.parse(stored) as BackfillProgress;
+    if (parsed.status === "running") {
+      parsed.status = "interrupted";
+      parsed.completedAt = parsed.lastBatchAt;
+      parsed.error = "Process restarted while backfill was running";
+    }
+    return parsed;
+  } catch {
+    return { ...backfillProgress };
+  }
 }
 
 /**
@@ -306,6 +329,7 @@ export async function backfillCatalogBooks(
     lastBatchAt: null,
     error: null,
   };
+  persistProgress(ctx.kv);
 
   try {
     while (true) {
@@ -345,18 +369,21 @@ export async function backfillCatalogBooks(
       backfillProgress.written = written;
       backfillProgress.batches = batches;
       backfillProgress.lastBatchAt = new Date().toISOString();
+      persistProgress(ctx.kv);
 
       await new Promise((r) => setTimeout(r, BATCH_DELAY_MS));
     }
 
     backfillProgress.status = "completed";
     backfillProgress.completedAt = new Date().toISOString();
+    persistProgress(ctx.kv);
     wideEvent["outcome"] = "success";
     return { written, batches };
   } catch (err) {
     backfillProgress.status = "failed";
     backfillProgress.completedAt = new Date().toISOString();
     backfillProgress.error = err instanceof Error ? err.message : String(err);
+    persistProgress(ctx.kv);
     wideEvent["outcome"] = "error";
     wideEvent["error"] =
       err instanceof Error ? { message: err.message, type: err.name } : String(err);

--- a/src/xrpc/router.ts
+++ b/src/xrpc/router.ts
@@ -2154,15 +2154,27 @@ export function createXrpcRouter<E extends XrpcContext, V extends { ctx: E } = {
 
       if (!hiveId && (title || authors)) {
         hiveId = await matchSyncDocument(ctx.db, { title, authors, filename });
-        if (hiveId) {
-          await ctx.db
-            .updateTable("sync_document")
-            .set({ hiveId })
-            .where("userDid", "=", userDid)
-            .where("provider", "=", "kosync")
-            .where("documentHash", "=", document)
-            .execute();
-        }
+      }
+
+      if (!hiveId) {
+        const pb = await ctx.db
+          .selectFrom("personal_book")
+          .select("hiveId")
+          .where("userDid", "=", userDid)
+          .where("contentHash", "=", document)
+          .executeTakeFirst();
+        if (pb?.hiveId) hiveId = pb.hiveId;
+      }
+
+      if (hiveId) {
+        await ctx.db
+          .updateTable("sync_document")
+          .set({ hiveId })
+          .where("userDid", "=", userDid)
+          .where("provider", "=", "kosync")
+          .where("documentHash", "=", document)
+          .where("hiveId", "is", null)
+          .execute();
       }
 
       if (hiveId) {


### PR DESCRIPTION
## Summary

- **Fix KOSync → public book progress bridging**: When an ebook was uploaded before the first KOSync sync, the `sync_document` was created with `hiveId: null` because the upload's propagation UPDATE hit 0 rows (sync_document didn't exist yet), and the KOSync handler's title/author auto-match never checked `personal_book` — the most reliable source, since they share the same KOReader content hash. All three sync progress handlers (KOSync REST, XRPC `PutSyncProgress`, and HTML form upload) now fall back to `personal_book.hiveId` when title/author matching fails.
- **HTML form upload auto-matching**: The browser upload path was missing the `matchSyncDocument` call that the XRPC upload path already had, and never propagated a matched `hiveId` back to `sync_document`.
- **Persist admin backfill progress to KV**: `backfillCatalogBooks` progress now survives process restarts — on read, a stale "running" status is reported as "interrupted".

## Test plan

- [x] `bun run typecheck` passes (no new errors)
- [x] `bun test src` passes (411/411)
- [ ] Upload an ebook via browser, then sync from KOReader — verify `sync_document.hiveId` is set and progress bridges to `user_book`
- [ ] Upload an ebook via XRPC, sync from KOReader — same verification
- [ ] Sync from KOReader first (no upload), then upload — verify hiveId propagates to existing `sync_document`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Library uploads can now match existing books using title, authors, and filename when an exact match is unavailable.
  - KOReader synchronization can recover book associations using additional book details.
  - Backfill progress is now saved and restored across interruptions or restarts.

- **Bug Fixes**
  - Existing book associations are preserved during synchronization.
  - Backfill jobs interrupted by a restart are clearly marked as interrupted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->