### PR TITLE
perf: one PDS round-trip per book write, and no page reload per click

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -459,33 +459,21 @@ look like App Store listing assets (light/dark and `-16` variants), so they are 
 | `LibraryManager` | `#mount-library-manager`                                                  | `src/client/components/LibraryManager.tsx`        |
 
 **`BookIslands`** (`src/client/components/book/`) is the signed-in half of `/books/:id`: status
-dropdown + owned toggle (hero card), the "Finished: 2 days ago" line, and the whole "Your
-Activity" card (rating, review, progress, dates, Save, re-read history, Remove). One
-`createUserBookStore` per page (`userBookStore.ts`) holds `{ view, confirmed, pending, error }`
-and the three components subscribe with `useSyncExternalStore` — they can't share a root because
-the hero and the activity card are two cards apart. Props arrive as JSON in
-`#mount-book-actions[data-props]` (`BookActionsProps`: `hiveId`, `title`, `authors`, `numPages`,
-`userBook: UserBookView | null`), built in `src/pages/bookInfo.tsx`. Three rules hold it together:
+and owned in the hero card, the timestamp line, and the whole "Your Activity" card. One
+`createUserBookStore` per page holds `{ view, confirmed, pending, error }` and the three
+components subscribe with `useSyncExternalStore` — they can't share a root, being cards apart.
+Props are JSON in `#mount-book-actions[data-props]`, built in `src/pages/bookInfo.tsx`.
 
-- **Every change is optimistic, and the server's `UserBookView` replaces it.** `applyOptimistic`
-  mirrors `inferBookStatusAndDates` and the re-read rotation so the first frame looks like the
-  confirmed one will; the JSON `/api/update-book` answer (one PDS round-trip) then becomes
-  `view`. On failure `view` snaps back to `confirmed` and a plain-language error renders under
-  the buttons (the server's message goes to `console.error` — it names CIDs and lexicon paths).
-  Verified in a browser against a real PDS: a status click paints at once, the POST lands
-  ~200–400 ms later with no navigation.
-- **Mutations are serialised, and a response never overwrites `view` while more are queued.**
-  The server holds a per-user lock and CAS's on the previous cid, so parallel writes would only
-  race each other; and applying response N on top of optimistic edit N+1 would briefly undo what
-  the user just did.
-- **The server-rendered forms inside the mounts are the pre-hydration paint**, replaced by
-  `render()` on load. They are also all a no-JS visitor gets — which is no worse than before,
-  since the status menu was already JS-only. The inline `<Script>`s for the dropdown, progress
-  auto-calc and delete dialog were removed with the island taking over; don't add them back.
+- **Changes are optimistic and replaced by the server's `UserBookView`.** `applyOptimistic`
+  mirrors `inferBookStatusAndDates`, so it must be updated whenever that is: a payload asserting
+  no status must leave status and dates alone, or the frame flickers back.
+- **Writes are serialised**, and a response never overwrites `view` while later ones are queued.
+  A delete blocks writes for its whole duration — the server re-creates the record otherwise.
+- **The server-rendered forms inside the mounts are the pre-hydration paint** and all a no-JS
+  visitor gets, so they keep their own inline `<Script>` handlers. Don't delete those again.
 
-`StarRating` (`src/client/components/StarRating.tsx`) is no longer mounted on its own — the
-activity panel renders it, and it now follows its `initialRating` prop so a rollback or a
-server reconcile shows in the stars.
+`StarRating` is no longer mounted on its own; the activity panel renders it, and it follows its
+`initialRating` prop so a rollback or reconcile shows in the stars.
 
 `LibraryManager` sub-components in `src/client/components/library/`: `AnchoredMenu.tsx`, `ShelfTabs.tsx`, `PersonalBookCard.tsx`, `SyncDocumentSections.tsx`, `types.ts`.
 
@@ -593,50 +581,26 @@ SQLite-backed unstorage. Mounts: `search:` (in-memory LRU), `profile:`, `identit
 
 ### The book write path (`src/utils/getBook.ts` → `updateBookRecord`)
 
-Every status click, rating and review edit goes through here, so it is built to
-be **one PDS round-trip**. It used to be two to four plus a scrape: `getRecord`
-to read the original, `ensureBookCataloged` (up to 20s inline when the book was
-not catalogued), a cover fetch from Goodreads' CDN + `Bun.Image` resize +
-`uploadBlob` on first add, then `applyWrites`. Three things replaced that, and
-each is load-bearing:
+Every status click, rating and review edit goes through here, so it is **one PDS round-trip**.
+It used to be two to four plus a scrape. Four things keep it correct:
 
-- **The merge source is the local row, not the PDS.** `user_book.record`
-  (migration 025) holds the last record seen for the row, verbatim, because the
-  record carries three fields the columns don't — `cover`, `identifiers`,
-  `hiveBookUri` — and merging without them would silently strip them.
-  `recordFromUserBook` rebuilds the record with **columns winning** over it:
-  KOSync progress (`syncBridge`, queued in `sync_pending:`) and `owned` from a
-  library upload are written to the columns before they reach the PDS, and
-  merging against the stored record alone would revert them on the next click.
-  Every full-record writer sets the column — the ingester (backfill + live),
-  `refetchBooks`, the admin backfill, and this path — and a null column (a row
-  older than the migration) falls back to `getRecord`. The wide event says which:
-  `book_merge_source: local | pds | pds_after_conflict`.
-- **The write is compare-and-swapped** (`bookRecordWrite.ts`): `putRecord` with
-  `swapRecord` = the cid we merged against. A merge computed from local state
-  must fail if the PDS holds something we have not seen (another device, the
-  iOS app, a third-party client). On `InvalidSwap` the record is re-read once,
-  re-merged with the same pure `buildBookRecord`, and re-written; a second
-  conflict throws. `applyWrites` was not usable here — it only offers
-  `swapCommit`, which is the whole repo and fails on any unrelated write.
-  `getBookRecord` no longer pins a cid for the same reason: a stale pin 404s,
-  which the old code read as "no record" and answered with a duplicate create.
-- **Cover and catalogue link are patched in after the response**
-  (`userBookFollowUp.ts`). BookHive renders neither from the record (covers
-  come from `hive_book`), so the person waiting on a click should not pay for
-  them. The request path reads `hive_book.hiveBookAtUri` only
-  (`getCatalogedBookUri`); the follow-up runs the full `ensureBookCataloged`
-  and `uploadImageBlob`, then one CAS `putRecord` on the cid the request wrote.
-  On conflict the patch is **dropped, not forced** — the next write to a
-  still-incomplete record schedules it again, and `refetchBooks` back-fills
-  `hiveBookUri` regardless. One in-flight task per record URI, 2 per process,
-  60s deadline. The request's wide event is written long before this resolves,
-  so `bookhive_user_book_follow_up_total{outcome}` is the only signal; a rising
-  `failed` there is the thing to look at when covers stop appearing on records.
-
-`updateBookRecord` returns `{ book, userBook, followUp }`; `followUp` never
-rejects. Handlers drop it, `src/utils/getBook.test.ts` awaits it. The bulk
-import path (`updateBookRecords`) is unchanged apart from setting `record`.
+- **The merge source is the local row, not the PDS.** `user_book.record` (migration 025) holds
+  the last record seen, because it carries three fields the columns don't — `cover`,
+  `identifiers`, `hiveBookUri` — and merging without them strips them. `recordFromUserBook`
+  rebuilds it with **columns winning**: KOSync progress and `owned` from an upload reach the row
+  before the PDS. Every full-record writer sets the column; a null one falls back to `getRecord`.
+  The wide event says which: `book_merge_source: local | pds | pds_after_conflict`.
+- **The write is compare-and-swapped** on the cid we merged against (`bookRecordWrite.ts`). On
+  `InvalidSwap` the record is re-read once and re-merged. `applyWrites` only offers `swapCommit`
+  (the whole repo), hence `putRecord`.
+- **Partial payloads must not invent state.** The island sends only what changed, so
+  `inferBookStatusAndDates` reads status _and_ dates off the record too: a missing status is not
+  "no status" (that downgraded finished books on a date edit), and a date is restamped only when
+  the book actually enters that status (else a rating save rewrote the user's start date).
+- **Cover and catalogue link are patched in after the response** (`userBookFollowUp.ts`), CAS'd
+  on the cid the request wrote and dropped on conflict. It writes only `cid`/`indexedAt`/`record`
+  — replaying the whole row reverted column-only writes. Outcomes land in
+  `bookhive_user_book_follow_up_total`; the request's wide event is gone by then.
 
 ### The upload core (`src/utils/uploadPersonalBook.ts`)
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -52,7 +52,7 @@ Worker threads (bundled to .output/server/workers/):
 
 **Key patterns:**
 
-- Server components (`src/pages/`) render full HTML. Only 6 islands are hydrated client-side (`src/client/`). Most interactivity is CSS-only (peer/checked selectors) or inline `<Script>` vanilla JS.
+- Server components (`src/pages/`) render full HTML. Only 6 islands are hydrated client-side (`src/client/`); one of them, the book page's `BookIslands`, renders into three mount points. Most interactivity is CSS-only (peer/checked selectors) or inline `<Script>` vanilla JS.
 - **Production is multi-process**: `server/cluster.ts` spawns `WEB_CONCURRENCY` workers sharing port 8080 via SO_REUSEPORT — the code defaults to 4, but the deployed container sets **3** (verified on the host), which is the number every memory ceiling in this document is derived from. Worker 0 is the **primary** (`isPrimaryWorker`): only it runs migrations, VACUUM, the Jetstream ingester, and the enrichment drain.
 - **Enrichment is queued, never inline**: routes call `enqueueEnrichment`/`enqueueEnrichmentBatch` (`src/utils/enrichQueue.ts`). The primary worker drains it every 5s at concurrency 3, with exponential backoff. `enrichBookWithDetailedData` holds its own semaphore (4) + 45s deadline. That drain interval × concurrency is also the **only** rate limit on requests to Goodreads — 36 fetches/min, healthy or not. Don't add a second one.
 - **`enrich_queue.attempts` counts answers from Goodreads, not failures.** A run reports `enrich_retry` in the wide-event bag: `retry` spends an attempt, `defer` costs nothing and re-queues on a decaying schedule, `dead` tombstones the book immediately. Anything the app decided on its own — a WAF challenge, a timeout, a transport error — is a `defer`. Getting this wrong is expensive: when refusals counted as attempts, one 6h window wrote off 2,854 books for 7 days apiece **without sending a single request on their behalf** (98% of everything the queue gave up on). The bound on defers is `MAX_QUEUE_AGE_MS` (7d from `enqueuedAt`, which survives re-enqueue), not the attempt counter.
@@ -95,13 +95,13 @@ Wide content (the library/import tables) already clips itself, so `<main>` does 
 
 ## Entry Points
 
-| File                   | Purpose                                                             |
-| ---------------------- | ------------------------------------------------------------------- |
-| `src/index.ts`         | Bun.serve — HTML bundle route + Hono fetch handler                  |
-| `src/server.ts`        | Wires deps via `createAppDeps()` + `createApp()`; graceful shutdown |
-| `src/app.ts`           | Hono app factory — all middleware + route mounting                  |
-| `src/entry.html`       | Bun HTML bundle entry (imports CSS + client JS)                     |
-| `src/client/index.tsx` | Client bundle entry — mounts 6 hydrated components                  |
+| File                   | Purpose                                                                        |
+| ---------------------- | ------------------------------------------------------------------------------ |
+| `src/index.ts`         | Bun.serve — HTML bundle route + Hono fetch handler                             |
+| `src/server.ts`        | Wires deps via `createAppDeps()` + `createApp()`; graceful shutdown            |
+| `src/app.ts`           | Hono app factory — all middleware + route mounting                             |
+| `src/entry.html`       | Bun HTML bundle entry (imports CSS + client JS)                                |
+| `src/client/index.tsx` | Client bundle entry — mounts the hydrated islands (see Client-Side Components) |
 
 ## Routes
 
@@ -448,14 +448,43 @@ look like App Store listing assets (light/dark and `-16` variants), so they are 
 
 6 hydration islands, mounted in `src/client/index.tsx`:
 
-| Component        | Mount Point              | File                                              |
-| ---------------- | ------------------------ | ------------------------------------------------- |
-| `SearchTrigger`  | `#mount-search-box`      | `src/client/components/SearchBox.tsx`             |
-| `SearchPalette`  | `#mount-search-palette`  | `src/client/components/SearchPalette.tsx`         |
-| `StarRating`     | `#star-rating`           | `src/client/components/StarRating.tsx`            |
-| `ImportTableApp` | `#import-table`          | `src/client/components/import/ImportTableApp.tsx` |
-| `LibraryTable`   | `#mount-library-table`   | `src/client/components/LibraryTable.tsx`          |
-| `LibraryManager` | `#mount-library-manager` | `src/client/components/LibraryManager.tsx`        |
+| Component        | Mount Point                                                               | File                                              |
+| ---------------- | ------------------------------------------------------------------------- | ------------------------------------------------- |
+| `SearchTrigger`  | `#mount-search-box`                                                       | `src/client/components/SearchBox.tsx`             |
+| `SearchPalette`  | `#mount-search-palette`                                                   | `src/client/components/SearchPalette.tsx`         |
+| `BookIslands`    | `#mount-book-actions` (+ `#mount-book-timestamp`, `#mount-book-activity`) | `src/client/components/book/index.tsx`            |
+| `ImportTableApp` | `#import-table`                                                           | `src/client/components/import/ImportTableApp.tsx` |
+| `LibraryTable`   | `#mount-library-table`                                                    | `src/client/components/LibraryTable.tsx`          |
+| `LibraryManager` | `#mount-library-manager`                                                  | `src/client/components/LibraryManager.tsx`        |
+
+**`BookIslands`** (`src/client/components/book/`) is the signed-in half of `/books/:id`: status
+dropdown + owned toggle (hero card), the "Finished: 2 days ago" line, and the whole "Your
+Activity" card (rating, review, progress, dates, Save, re-read history, Remove). One
+`createUserBookStore` per page (`userBookStore.ts`) holds `{ view, confirmed, pending, error }`
+and the three components subscribe with `useSyncExternalStore` — they can't share a root because
+the hero and the activity card are two cards apart. Props arrive as JSON in
+`#mount-book-actions[data-props]` (`BookActionsProps`: `hiveId`, `title`, `authors`, `numPages`,
+`userBook: UserBookView | null`), built in `src/pages/bookInfo.tsx`. Three rules hold it together:
+
+- **Every change is optimistic, and the server's `UserBookView` replaces it.** `applyOptimistic`
+  mirrors `inferBookStatusAndDates` and the re-read rotation so the first frame looks like the
+  confirmed one will; the JSON `/api/update-book` answer (one PDS round-trip) then becomes
+  `view`. On failure `view` snaps back to `confirmed` and a plain-language error renders under
+  the buttons (the server's message goes to `console.error` — it names CIDs and lexicon paths).
+  Verified in a browser against a real PDS: a status click paints at once, the POST lands
+  ~200–400 ms later with no navigation.
+- **Mutations are serialised, and a response never overwrites `view` while more are queued.**
+  The server holds a per-user lock and CAS's on the previous cid, so parallel writes would only
+  race each other; and applying response N on top of optimistic edit N+1 would briefly undo what
+  the user just did.
+- **The server-rendered forms inside the mounts are the pre-hydration paint**, replaced by
+  `render()` on load. They are also all a no-JS visitor gets — which is no worse than before,
+  since the status menu was already JS-only. The inline `<Script>`s for the dropdown, progress
+  auto-calc and delete dialog were removed with the island taking over; don't add them back.
+
+`StarRating` (`src/client/components/StarRating.tsx`) is no longer mounted on its own — the
+activity panel renders it, and it now follows its `initialRating` prop so a rollback or a
+server reconcile shows in the stars.
 
 `LibraryManager` sub-components in `src/client/components/library/`: `AnchoredMenu.tsx`, `ShelfTabs.tsx`, `PersonalBookCard.tsx`, `SyncDocumentSections.tsx`, `types.ts`.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -547,7 +547,7 @@ SQLite-backed unstorage. Mounts: `search:` (in-memory LRU), `profile:`, `identit
 | `getBook.ts`            | Book record CRUD against user's PDS. `updateBookRecord` is the interactive write — see "The book write path" below                                                                                                                                                                                                                                                                                                            |
 | `userBookStore.ts`      | `user_book` row read/upsert + `recordFromUserBook` (local merge source). Apart from `getBook.ts` so the follow-up can import it without a cycle                                                                                                                                                                                                                                                                               |
 | `bookRecordWrite.ts`    | CAS write of a book record (`putRecord` + `swapRecord`, `createRecord` for new). There is deliberately no unguarded variant                                                                                                                                                                                                                                                                                                   |
-| `userBookFollowUp.ts`   | Deferred cover-blob upload + `hiveBookUri` patch after the response; CAS'd on the cid the request wrote, dropped on conflict. Outcomes in `bookhive_user_book_follow_up_total`                                                                                                                                                                                                                                                |
+| `userBookFollowUp.ts`   | Deferred cover-blob upload + `hiveBookUri` patch after the response; CAS'd, and on conflict re-read and re-applied (3 attempts) — see the write-path note. Outcomes in `bookhive_user_book_follow_up_total`                                                                                                                                                                                                                   |
 | `userBookView.ts`       | `UserBookView` + `toUserBookView` — the wire shape for book-state reads/writes                                                                                                                                                                                                                                                                                                                                                |
 | `getProfile.ts`         | Profile fetching from Bluesky                                                                                                                                                                                                                                                                                                                                                                                                 |
 | `getFollows.ts`         | Follow graph sync                                                                                                                                                                                                                                                                                                                                                                                                             |
@@ -598,9 +598,16 @@ It used to be two to four plus a scrape. Four things keep it correct:
   "no status" (that downgraded finished books on a date edit), and a date is restamped only when
   the book actually enters that status (else a rating save rewrote the user's start date).
 - **Cover and catalogue link are patched in after the response** (`userBookFollowUp.ts`), CAS'd
-  on the cid the request wrote and dropped on conflict. It writes only `cid`/`indexedAt`/`record`
-  — replaying the whole row reverted column-only writes. Outcomes land in
-  `bookhive_user_book_follow_up_total`; the request's wide event is gone by then.
+  on the cid the request wrote. **A lost CAS race is re-read and re-applied (3 attempts), not
+  dropped** — losing to the user's own next edit is the _common_ case (first add, then a rating
+  click while the cover uploads), and nothing ever re-supplies the cover: the island sends no
+  `coverImage` and the merge builds from a record without one, so a dropped patch lost the
+  cover for good. The blob upload/scrape run once; only the write retries, patching only the
+  fields the fresh record still lacks. The row update stays guarded on the cid that was
+  swapped on, so a row that moved on is left alone (the next write CAS-heals it). It writes
+  only `cid`/`indexedAt`/`record` — replaying the whole row reverted column-only writes.
+  Outcomes land in `bookhive_user_book_follow_up_total`; the request's wide event is gone by
+  then.
 
 ### The upload core (`src/utils/uploadPersonalBook.ts`)
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -251,7 +251,8 @@ Personal library: ebook uploads, e-reader credentials, sync documents. All auth-
 ### `src/routes/api.tsx` (mounted at `/api`)
 
 - GET `/user-book?hiveId=` → `{ userBook: UserBookView | null }` for the signed-in viewer. Cookie DID only (`getSessionDid`) — no OAuth restore, it never touches the PDS
-- POST `/update-book` → JSON write; returns `{ success, message, userBook: UserBookView }`. `/update-comment`
+- POST `/update-book` → JSON write; returns `{ success, message, userBook: UserBookView }`
+- POST `/update-comment` → create/update a buzz on a book
 
 **`UserBookView`** (`src/utils/userBookView.ts`) is the one shape every book-state write returns and the read answers with — the `user_book` row minus `userDid` and the raw PDS `record`, with `owned` as a boolean. It exists so a client can update optimistically and reconcile with what was actually written instead of reloading the page.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -214,7 +214,7 @@ Two traps this encodes, both of which caused real bugs:
 
 - GET `/:hiveId` → `src/pages/bookInfo.tsx` — book detail. `hiveId` must match `^bk_[A-Za-z0-9]+$`. Stale books (>30d) queued for enrichment; `?force-refresh=true` enriches inline with 15s ceiling
 - DELETE `/:hiveId` → delete book from PDS + DB
-- POST `/` → add/update book (zValidator form); per-DID `book_lock` KV, 429 if locked
+- POST `/` → add/update book (zValidator form); per-DID `book_lock` KV, 429 if locked. Answers `{ success, userBook: UserBookView }` when the request's `Accept` includes `application/json`, otherwise a 302 back to the book (the no-JS path)
 - GET `/:hiveId/comments` → `src/pages/comments.tsx`
 
 ### `src/routes/comments.tsx` (mounted at `/comments`)
@@ -250,7 +250,11 @@ Personal library: ebook uploads, e-reader credentials, sync documents. All auth-
 
 ### `src/routes/api.tsx` (mounted at `/api`)
 
-- POST `/update-book`, `/update-comment`
+- GET `/user-book?hiveId=` → `{ userBook: UserBookView | null }` for the signed-in viewer. Cookie DID only (`getSessionDid`) — no OAuth restore, it never touches the PDS
+- POST `/update-book` → JSON write; returns `{ success, message, userBook: UserBookView }`. `/update-comment`
+
+**`UserBookView`** (`src/utils/userBookView.ts`) is the one shape every book-state write returns and the read answers with — the `user_book` row minus `userDid` and the raw PDS `record`, with `owned` as a boolean. It exists so a client can update optimistically and reconcile with what was actually written instead of reloading the page.
+
 - POST `/follow`, `/follow-form`, `/unfollow`, `/unfollow-form`
 
 ### `src/routes/rss.ts` (mounted at `/rss`)
@@ -464,13 +468,13 @@ Client hooks/utils: `useSearchBooks.ts`, `useDebounce.ts`, `icons.tsx`, `debounc
 
 ### Database (`src/db.ts`)
 
-SQLite via Kysely. Schema + all migrations (001–024) in one file. `createDb` sets WAL/perf PRAGMAs. `mmap_size` defaults to 0 (see `DB_MMAP_SIZE` in `src/env.ts`). Kysely talks to `bun:sqlite` through `src/bun-sqlite-kysely.ts`, which rewrites `begin` to `BEGIN IMMEDIATE` (deferred transactions fail with `SQLITE_BUSY_SNAPSHOT` across cluster processes).
+SQLite via Kysely. Schema + all migrations (001–025) in one file. `createDb` sets WAL/perf PRAGMAs. `mmap_size` defaults to 0 (see `DB_MMAP_SIZE` in `src/env.ts`). Kysely talks to `bun:sqlite` through `src/bun-sqlite-kysely.ts`, which rewrites `begin` to `BEGIN IMMEDIATE` (deferred transactions fail with `SQLITE_BUSY_SNAPSHOT` across cluster processes).
 
 That wrapper also decides `statement.reader`, which is how Kysely picks `all()` (rows) over `run()` (changes). **It asks SQLite — `stmt.columnNames` is empty for anything that doesn't produce rows — rather than pattern-matching the SQL text.** The old regex was anchored on a leading `SELECT`, so `WITH cte AS (…) SELECT …` was classified as a write and Kysely got **zero rows with no error of any kind**; the author-directory cover lookup is a window function over a CTE and silently returned nothing. `columnNames` also gets the converse right, which a regex struggles with: `WITH cte AS (…) INSERT INTO …` is not a reader.
 
 | Table                 | Purpose                   | Key columns                                                                                                                                                                                              |
 | --------------------- | ------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `user_book`           | User's book records       | uri (PK), userDid, hiveId, title, authors, status, **stars** (not `rating`), review, startedAt, finishedAt, **owned** (bool), bookProgress, previousReads (JSON)                                         |
+| `user_book`           | User's book records       | uri (PK), userDid, hiveId, title, authors, status, **stars** (not `rating`), review, startedAt, finishedAt, **owned** (bool), bookProgress, previousReads (JSON), **record** (JSON, mig 025 — see below) |
 | `hive_book`           | Canonical book data       | id (HiveId, PK), title, authors (**tab-separated**), cover, thumbnail, description, rating, ratingsCount, series, meta, enrichedAt, enrichAttempts, enrichFailedAt, identifiers, hiveBookAtUri, language |
 | `hive_book_genre`     | Genre-to-book mapping     | hiveId, genre (UNIQUE pair). **Genres live ONLY here**                                                                                                                                                   |
 | `hive_book_fts`       | FTS5 search index         | External-content FTS5 over `hive_book(title, rawTitle, authors)`, trigger-maintained. Never written directly. **Rebuilt after VACUUM** — see below                                                       |
@@ -522,7 +526,11 @@ SQLite-backed unstorage. Mounts: `search:` (in-memory LRU), `profile:`, `identit
 
 | File                    | Purpose                                                                                                                                                                                                                                                                                                                                                                                                                       |
 | ----------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `getBook.ts`            | Book record CRUD against user's PDS                                                                                                                                                                                                                                                                                                                                                                                           |
+| `getBook.ts`            | Book record CRUD against user's PDS. `updateBookRecord` is the interactive write — see "The book write path" below                                                                                                                                                                                                                                                                                                            |
+| `userBookStore.ts`      | `user_book` row read/upsert + `recordFromUserBook` (local merge source). Apart from `getBook.ts` so the follow-up can import it without a cycle                                                                                                                                                                                                                                                                               |
+| `bookRecordWrite.ts`    | CAS write of a book record (`putRecord` + `swapRecord`, `createRecord` for new). There is deliberately no unguarded variant                                                                                                                                                                                                                                                                                                   |
+| `userBookFollowUp.ts`   | Deferred cover-blob upload + `hiveBookUri` patch after the response; CAS'd on the cid the request wrote, dropped on conflict. Outcomes in `bookhive_user_book_follow_up_total`                                                                                                                                                                                                                                                |
+| `userBookView.ts`       | `UserBookView` + `toUserBookView` — the wire shape for book-state reads/writes                                                                                                                                                                                                                                                                                                                                                |
 | `getProfile.ts`         | Profile fetching from Bluesky                                                                                                                                                                                                                                                                                                                                                                                                 |
 | `getFollows.ts`         | Follow graph sync                                                                                                                                                                                                                                                                                                                                                                                                             |
 | `enrichBookData.ts`     | Goodreads enrichment (semaphore-bounded, 45s deadline)                                                                                                                                                                                                                                                                                                                                                                        |
@@ -552,6 +560,53 @@ SQLite-backed unstorage. Mounts: `search:` (in-memory LRU), `profile:`, `identit
 | `manifest.ts`           | Vite manifest → asset URLs                                                                                                                                                                                                                                                                                                                                                                                                    |
 | `xml.ts`                | XML utilities                                                                                                                                                                                                                                                                                                                                                                                                                 |
 | Other                   | `getLanguages.ts`, `catalogBookService.ts`, `deleteAccount.ts`, `dbExport.ts`, `generateInitialsAvatar.ts`, `htmlToText.ts`, `batchTransform.ts`, `lazy.ts`, `hiveBookGenres.ts`, `ensureBookCataloged.ts`, `uploadImageBlob.ts`                                                                                                                                                                                              |
+
+### The book write path (`src/utils/getBook.ts` → `updateBookRecord`)
+
+Every status click, rating and review edit goes through here, so it is built to
+be **one PDS round-trip**. It used to be two to four plus a scrape: `getRecord`
+to read the original, `ensureBookCataloged` (up to 20s inline when the book was
+not catalogued), a cover fetch from Goodreads' CDN + `Bun.Image` resize +
+`uploadBlob` on first add, then `applyWrites`. Three things replaced that, and
+each is load-bearing:
+
+- **The merge source is the local row, not the PDS.** `user_book.record`
+  (migration 025) holds the last record seen for the row, verbatim, because the
+  record carries three fields the columns don't — `cover`, `identifiers`,
+  `hiveBookUri` — and merging without them would silently strip them.
+  `recordFromUserBook` rebuilds the record with **columns winning** over it:
+  KOSync progress (`syncBridge`, queued in `sync_pending:`) and `owned` from a
+  library upload are written to the columns before they reach the PDS, and
+  merging against the stored record alone would revert them on the next click.
+  Every full-record writer sets the column — the ingester (backfill + live),
+  `refetchBooks`, the admin backfill, and this path — and a null column (a row
+  older than the migration) falls back to `getRecord`. The wide event says which:
+  `book_merge_source: local | pds | pds_after_conflict`.
+- **The write is compare-and-swapped** (`bookRecordWrite.ts`): `putRecord` with
+  `swapRecord` = the cid we merged against. A merge computed from local state
+  must fail if the PDS holds something we have not seen (another device, the
+  iOS app, a third-party client). On `InvalidSwap` the record is re-read once,
+  re-merged with the same pure `buildBookRecord`, and re-written; a second
+  conflict throws. `applyWrites` was not usable here — it only offers
+  `swapCommit`, which is the whole repo and fails on any unrelated write.
+  `getBookRecord` no longer pins a cid for the same reason: a stale pin 404s,
+  which the old code read as "no record" and answered with a duplicate create.
+- **Cover and catalogue link are patched in after the response**
+  (`userBookFollowUp.ts`). BookHive renders neither from the record (covers
+  come from `hive_book`), so the person waiting on a click should not pay for
+  them. The request path reads `hive_book.hiveBookAtUri` only
+  (`getCatalogedBookUri`); the follow-up runs the full `ensureBookCataloged`
+  and `uploadImageBlob`, then one CAS `putRecord` on the cid the request wrote.
+  On conflict the patch is **dropped, not forced** — the next write to a
+  still-incomplete record schedules it again, and `refetchBooks` back-fills
+  `hiveBookUri` regardless. One in-flight task per record URI, 2 per process,
+  60s deadline. The request's wide event is written long before this resolves,
+  so `bookhive_user_book_follow_up_total{outcome}` is the only signal; a rising
+  `failed` there is the thing to look at when covers stop appearing on records.
+
+`updateBookRecord` returns `{ book, userBook, followUp }`; `followUp` never
+rejects. Handlers drop it, `src/utils/getBook.test.ts` awaits it. The bulk
+import path (`updateBookRecords`) is unchanged apart from setting `record`.
 
 ### The upload core (`src/utils/uploadPersonalBook.ts`)
 

--- a/src/bsky/ingester.ts
+++ b/src/bsky/ingester.ts
@@ -163,6 +163,7 @@ async function backfillUserRepo(
                   stars: book.stars ?? null,
                   bookProgress: book.bookProgress ?? null,
                   previousReads: book.previousReads ?? null,
+                  record: book,
                 } satisfies UserBook),
               );
             for (let i = 0; i < rowsToInsert.length; i += 100) {
@@ -421,6 +422,7 @@ export function createIngester(
                 stars: book.stars ?? null,
                 bookProgress: book.bookProgress ?? null,
                 previousReads: book.previousReads ?? null,
+                record: book,
               } satisfies UserBook),
             )
             .onConflict((oc) =>
@@ -440,6 +442,7 @@ export function createIngester(
                 createdAt: c.ref("excluded.createdAt"),
                 bookProgress: c.ref("excluded.bookProgress"),
                 previousReads: c.ref("excluded.previousReads"),
+                record: c.ref("excluded.record"),
               })),
             )
             .execute();

--- a/src/client/components/StarRating.tsx
+++ b/src/client/components/StarRating.tsx
@@ -23,8 +23,7 @@ export function calculateStars(rating: number): StarType[] {
 
 export const StarRating: FC<StarRatingProps> = ({ initialRating = 0, onChange }) => {
   const [rating, setRating] = useState(initialRating);
-  // Follow the prop: the book page's store replaces it with the server's
-  // answer, and a rollback after a failed write has to be visible here too.
+  // Follow the prop so a server reconcile or a rollback is visible here.
   useEffect(() => setRating(initialRating), [initialRating]);
   const [hoverRating, setHoverRating] = useState<number | null>(null);
   const containerRef = useRef<HTMLDivElement>(null);
@@ -63,6 +62,10 @@ export const StarRating: FC<StarRatingProps> = ({ initialRating = 0, onChange })
   const handleMouseDown = (event: MouseEvent) => {
     setIsDragging(true);
     const newRating = calculateRatingFromEvent(event);
+    // A click on the leftmost sliver computes 0, which consumers treat as "no
+    // change" — painting it would strand the widget at empty, since the prop
+    // never moves back.
+    if (!newRating) return;
     setRating(newRating);
     onChange?.(newRating);
   };

--- a/src/client/components/StarRating.tsx
+++ b/src/client/components/StarRating.tsx
@@ -1,4 +1,4 @@
-import { useState, useRef, type FC } from "hono/jsx/dom";
+import { useEffect, useState, useRef, type FC } from "hono/jsx/dom";
 
 type StarType = "full" | "half" | "empty";
 
@@ -23,6 +23,9 @@ export function calculateStars(rating: number): StarType[] {
 
 export const StarRating: FC<StarRatingProps> = ({ initialRating = 0, onChange }) => {
   const [rating, setRating] = useState(initialRating);
+  // Follow the prop: the book page's store replaces it with the server's
+  // answer, and a rollback after a failed write has to be visible here too.
+  useEffect(() => setRating(initialRating), [initialRating]);
   const [hoverRating, setHoverRating] = useState<number | null>(null);
   const containerRef = useRef<HTMLDivElement>(null);
   const [isDragging, setIsDragging] = useState(false);

--- a/src/client/components/StarRating.tsx
+++ b/src/client/components/StarRating.tsx
@@ -60,12 +60,13 @@ export const StarRating: FC<StarRatingProps> = ({ initialRating = 0, onChange })
   };
 
   const handleMouseDown = (event: MouseEvent) => {
-    setIsDragging(true);
     const newRating = calculateRatingFromEvent(event);
     // A click on the leftmost sliver computes 0, which consumers treat as "no
     // change" — painting it would strand the widget at empty, since the prop
-    // never moves back.
+    // never moves back. Bail before entering the drag state: a no-op click
+    // that set it left hover previews suppressed until the next mouseup.
     if (!newRating) return;
+    setIsDragging(true);
     setRating(newRating);
     onChange?.(newRating);
   };

--- a/src/client/components/book/BookActionRow.tsx
+++ b/src/client/components/book/BookActionRow.tsx
@@ -1,0 +1,149 @@
+import { useEffect, useRef, useState, useSyncExternalStore, type FC } from "hono/jsx/dom";
+
+import { STATUS, type UserBookStore } from "./userBookStore";
+
+const STATUS_OPTIONS = [
+  { value: STATUS.FINISHED, label: "Read" },
+  { value: STATUS.READING, label: "Reading" },
+  { value: STATUS.WANT_TO_READ, label: "Want to Read" },
+  { value: STATUS.ABANDONED, label: "Abandoned" },
+] as const;
+
+const STATUS_LABEL: Record<string, string> = {
+  [STATUS.FINISHED]: "Read",
+  [STATUS.READING]: "Reading",
+  [STATUS.WANT_TO_READ]: "Want to Read",
+  [STATUS.ABANDONED]: "Abandoned",
+};
+
+export function useUserBook(store: UserBookStore) {
+  return useSyncExternalStore(store.subscribe, store.getSnapshot, store.getSnapshot);
+}
+
+const pillClass = (active: boolean) =>
+  `cursor-pointer rounded-lg text-sm font-semibold shadow-sm transition-[background-color,scale,opacity] duration-150 active:scale-[0.96] focus:ring-2 focus:ring-primary focus:outline-none ${
+    active
+      ? "bg-primary text-primary-foreground hover:bg-primary/90"
+      : "bg-accent text-accent-foreground hover:bg-accent/80"
+  }`;
+
+export const BookActionRow: FC<{ store: UserBookStore }> = ({ store }) => {
+  const { view, pending } = useUserBook(store);
+  const [open, setOpen] = useState(false);
+  const rootRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    const onDocClick = (e: MouseEvent) => {
+      if (!rootRef.current?.contains(e.target as Node)) setOpen(false);
+    };
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") setOpen(false);
+    };
+    document.addEventListener("click", onDocClick);
+    document.addEventListener("keydown", onKey);
+    return () => {
+      document.removeEventListener("click", onDocClick);
+      document.removeEventListener("keydown", onKey);
+    };
+  }, [open]);
+
+  const status = view?.status ?? null;
+  const busy = pending > 0;
+
+  return (
+    <>
+      <div class="relative" ref={rootRef}>
+        <button
+          type="button"
+          aria-haspopup="listbox"
+          aria-expanded={open ? "true" : "false"}
+          aria-busy={busy ? "true" : "false"}
+          class={`${pillClass(!!status)} px-4 py-2 ${busy ? "opacity-80" : ""}`}
+          onClick={() => setOpen((o) => !o)}
+        >
+          <span class="flex items-center gap-1.5 capitalize">
+            <span>{(status && STATUS_LABEL[status]) || status || "Want to Read"}</span>
+            <svg
+              class="h-4 w-4 opacity-70"
+              viewBox="0 0 20 20"
+              fill="currentColor"
+              aria-hidden="true"
+            >
+              <path
+                fill-rule="evenodd"
+                d="M5.23 7.21a.75.75 0 011.06.02L10 11.168l3.71-3.938a.75.75 0 111.08 1.04l-4.25 4.5a.75.75 0 01-1.08 0l-4.25-4.5a.75.75 0 01.02-1.06z"
+                clip-rule="evenodd"
+              />
+            </svg>
+          </span>
+        </button>
+        <div
+          role="listbox"
+          class={`absolute z-10 mt-1 w-48 rounded-lg bg-card shadow-lg ring-1 ring-border transition-[opacity,visibility] duration-100 ease-in-out ${
+            open ? "visible opacity-100" : "invisible opacity-0"
+          }`}
+        >
+          <div class="p-1">
+            {STATUS_OPTIONS.map((option) => {
+              const selected = status === option.value;
+              return (
+                <button
+                  key={option.value}
+                  type="button"
+                  role="option"
+                  aria-selected={selected ? "true" : "false"}
+                  class={`relative my-0.5 w-full cursor-pointer rounded-[4px] px-3 py-2 text-left text-sm ${
+                    selected
+                      ? "bg-primary text-primary-foreground"
+                      : "text-foreground hover:bg-muted"
+                  }`}
+                  onClick={() => {
+                    setOpen(false);
+                    if (!selected) void store.update({ status: option.value });
+                  }}
+                >
+                  <span class="block truncate">{option.label}</span>
+                  {selected && (
+                    <span class="absolute inset-y-0 right-2 flex items-center" aria-hidden="true">
+                      <svg class="h-4 w-4" viewBox="0 0 20 20" fill="currentColor">
+                        <path
+                          fill-rule="evenodd"
+                          d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z"
+                          clip-rule="evenodd"
+                        />
+                      </svg>
+                    </span>
+                  )}
+                </button>
+              );
+            })}
+          </div>
+        </div>
+      </div>
+
+      <button
+        type="button"
+        aria-pressed={view?.owned ? "true" : "false"}
+        class={`${pillClass(!!view?.owned)} px-3 py-2`}
+        onClick={() => void store.update({ owned: !view?.owned })}
+      >
+        <span class="flex items-center gap-1.5">
+          <svg
+            class="h-4 w-4"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="2"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+          >
+            <path d="M4 19.5A2.5 2.5 0 016.5 17H20" />
+            <path d="M6.5 2H20v20H6.5A2.5 2.5 0 014 19.5v-15A2.5 2.5 0 016.5 2z" />
+          </svg>
+          {view?.owned ? "Owned" : "Own"}
+        </span>
+      </button>
+    </>
+  );
+};

--- a/src/client/components/book/BookActivityPanel.tsx
+++ b/src/client/components/book/BookActivityPanel.tsx
@@ -1,0 +1,421 @@
+import { format, formatDistanceToNow } from "date-fns";
+import { useEffect, useRef, useState, type FC } from "hono/jsx/dom";
+
+import type { UserBookView } from "../../../utils/userBookView";
+import { StarRating } from "../StarRating";
+import { useUserBook } from "./BookActionRow";
+import {
+  STATUS,
+  type BookActionsProps,
+  type UpdateFields,
+  type UserBookStore,
+} from "./userBookStore";
+
+type Draft = {
+  review: string;
+  currentPage: string;
+  totalPages: string;
+  currentChapter: string;
+  totalChapters: string;
+  percent: string;
+  startedAt: string;
+  finishedAt: string;
+};
+
+const toDateInput = (iso: string | null | undefined) => (iso ? iso.slice(0, 10) : "");
+const str = (n: number | null | undefined) => (n === null || n === undefined ? "" : String(n));
+
+function draftFrom(view: UserBookView | null, numPages: number | null): Draft {
+  const p = view?.bookProgress;
+  return {
+    review: view?.review ?? "",
+    currentPage: str(p?.currentPage),
+    totalPages: str(p?.totalPages ?? numPages),
+    currentChapter: str(p?.currentChapter),
+    totalChapters: str(p?.totalChapters),
+    percent: str(p?.percent),
+    startedAt: toDateInput(view?.startedAt),
+    finishedAt: toDateInput(view?.finishedAt),
+  };
+}
+
+const num = (s: string) => {
+  if (s.trim() === "") return undefined;
+  const n = Number(s);
+  return Number.isFinite(n) ? n : undefined;
+};
+
+/** Same rule the old inline script used: pages win, then chapters. */
+function derivedPercent(d: Draft): number | null {
+  const cp = num(d.currentPage);
+  const tp = num(d.totalPages);
+  const cc = num(d.currentChapter);
+  const tc = num(d.totalChapters);
+  if (cp !== undefined && tp && tp > 0)
+    return Math.min(100, Math.max(0, Math.round((cp / tp) * 100)));
+  if (cc !== undefined && tc && tc > 0)
+    return Math.min(100, Math.max(0, Math.round((cc / tc) * 100)));
+  return null;
+}
+
+const inputClass = "input focus-ring w-20 px-2 py-1.5 text-sm";
+const dateClass =
+  "rounded-md border border-border bg-card px-2 py-1.5 text-sm text-foreground shadow-sm focus:border-primary focus:ring-1 focus:ring-primary focus:outline-none";
+
+/** The line under the action buttons: the save error, if any, then "Finished: 2 days ago". */
+export const BookUserTimestamp: FC<{ store: UserBookStore }> = ({ store }) => {
+  const { view, error } = useUserBook(store);
+  const when = view ? (view.finishedAt ?? view.startedAt ?? view.createdAt) : null;
+  const label = view?.finishedAt ? "Finished" : view?.startedAt ? "Started" : "Added";
+  return (
+    <>
+      {error && (
+        <p role="alert" class="mb-3 flex items-center gap-3 text-sm text-destructive">
+          <span style={{ textWrap: "pretty" }}>{error}</span>
+          <button
+            type="button"
+            class="cursor-pointer underline underline-offset-2 hover:no-underline"
+            onClick={() => store.dismissError()}
+          >
+            Dismiss
+          </button>
+        </p>
+      )}
+      {when && (
+        <p class="mb-4 text-sm text-muted-foreground">
+          {`${label}: ${formatDistanceToNow(new Date(when), { addSuffix: true })}`}
+        </p>
+      )}
+    </>
+  );
+};
+
+export const BookActivityPanel: FC<{ store: UserBookStore; props: BookActionsProps }> = ({
+  store,
+  props,
+}) => {
+  const { view, confirmed, pending, savedAt } = useUserBook(store);
+  const [draft, setDraft] = useState<Draft>(() => draftFrom(view, props.numPages));
+  // Fields the user has edited since the last save. Everything else follows
+  // the server, so a status click that sets finishedAt shows up in the date
+  // box without wiping a half-written review.
+  const [touched, setTouched] = useState<Set<keyof Draft>>(() => new Set());
+  const dialogRef = useRef<HTMLDialogElement>(null);
+  const lastConfirmedCid = useRef(confirmed?.cid ?? null);
+
+  useEffect(() => {
+    const cid = confirmed?.cid ?? null;
+    if (cid === lastConfirmedCid.current) return;
+    lastConfirmedCid.current = cid;
+    const fresh = draftFrom(confirmed, props.numPages);
+    setDraft((d) => {
+      const next = { ...fresh };
+      for (const key of touched) next[key] = d[key];
+      return next;
+    });
+  }, [confirmed?.cid]);
+
+  const edit = (key: keyof Draft, value: string) => {
+    setTouched((t) => new Set(t).add(key));
+    setDraft((d) => {
+      const next = { ...d, [key]: value };
+      if (key !== "percent" && key !== "review" && key !== "startedAt" && key !== "finishedAt") {
+        const pct = derivedPercent(next);
+        if (pct !== null) next.percent = String(pct);
+      }
+      return next;
+    });
+  };
+
+  const finished = view?.status === STATUS.FINISHED;
+  const livePercent = finished ? 100 : (num(draft.percent) ?? view?.bookProgress?.percent ?? null);
+
+  const onSave = (e: Event) => {
+    e.preventDefault();
+    const fields: UpdateFields = {};
+    if (touched.has("review")) fields.review = draft.review;
+    if (touched.has("startedAt")) fields.startedAt = draft.startedAt;
+    if (touched.has("finishedAt")) fields.finishedAt = draft.finishedAt;
+    const progressTouched = (
+      ["currentPage", "totalPages", "currentChapter", "totalChapters", "percent"] as const
+    ).some((k) => touched.has(k));
+    if (!finished && progressTouched) {
+      const progress = {
+        currentPage: num(draft.currentPage),
+        totalPages: num(draft.totalPages),
+        currentChapter: num(draft.currentChapter),
+        totalChapters: num(draft.totalChapters),
+        percent: num(draft.percent),
+      };
+      if (Object.values(progress).some((v) => v !== undefined)) fields.bookProgress = progress;
+    }
+    setTouched(new Set());
+    if (Object.keys(fields).length === 0 && view) return;
+    void store.update(fields, { explicitSave: true });
+  };
+
+  const justSaved = savedAt !== null && Date.now() - savedAt < 2500;
+  const [, tick] = useState(0);
+  useEffect(() => {
+    if (!justSaved) return;
+    const t = setTimeout(() => tick((n) => n + 1), 2500);
+    return () => clearTimeout(t);
+  }, [savedAt]);
+
+  const previousReads = view?.previousReads ?? [];
+
+  return (
+    <div class="card-body space-y-6">
+      <h2 class="card-title">Your Activity</h2>
+
+      <form onSubmit={onSave}>
+        <div class="space-y-6">
+          <div>
+            <label class="mb-2 block text-sm font-semibold text-foreground">Your Rating</label>
+            <div class="flex cursor-pointer">
+              <StarRating
+                initialRating={view?.stars ?? 0}
+                onChange={(stars) => void store.update({ stars })}
+              />
+            </div>
+          </div>
+
+          <div>
+            <label class="mb-2 block text-sm font-semibold text-foreground" htmlFor="review-input">
+              {view?.review ? "Your Review" : "Write a Review"}
+            </label>
+            <div class="grid">
+              <textarea
+                id="review-input"
+                class="col-start-1 row-start-1 min-h-[100px] w-full overflow-hidden rounded-md border-0 bg-card py-2 text-foreground shadow-xs ring-1 ring-border ring-inset placeholder:text-muted-foreground focus:ring-2 focus:ring-primary focus:ring-inset sm:text-sm"
+                style={{ resize: "none", gridArea: "1 / 1 / 2 / 2" }}
+                placeholder="What did you think of this book?"
+                name="review"
+                value={draft.review}
+                onInput={(e) => edit("review", (e.target as HTMLTextAreaElement).value)}
+              />
+              <div
+                class="invisible col-start-1 row-start-1 overflow-hidden px-3 py-2 break-words whitespace-pre-wrap"
+                aria-hidden="true"
+              >
+                {draft.review || " "}
+              </div>
+            </div>
+          </div>
+
+          <div>
+            <label class="mb-2 block text-sm font-semibold text-foreground">Reading Progress</label>
+            {finished ? (
+              <>
+                <div class="mb-3 h-2 w-full overflow-hidden rounded-full bg-muted">
+                  <div
+                    class="h-full rounded-full bg-green-500 transition-[width] duration-300"
+                    style="width: 100%"
+                  />
+                </div>
+                <p class="text-sm text-muted-foreground">
+                  <span class="font-medium text-green-600 dark:text-green-400">Finished!</span>
+                  {(() => {
+                    const pages = view?.bookProgress?.totalPages ?? props.numPages;
+                    const chapters = view?.bookProgress?.totalChapters;
+                    return (
+                      <>
+                        {pages && <span class="ml-1">{pages} pages read</span>}
+                        {pages && chapters && <span> · </span>}
+                        {chapters && <span>{chapters} chapters</span>}
+                      </>
+                    );
+                  })()}
+                </p>
+              </>
+            ) : (
+              <>
+                {!!livePercent && (
+                  <div class="mb-3 h-2 w-full overflow-hidden rounded-full bg-muted">
+                    <div
+                      class="h-full rounded-full bg-primary transition-[width] duration-300"
+                      style={`width: ${livePercent}%`}
+                    />
+                  </div>
+                )}
+                <div class="flex items-center gap-2">
+                  <label class="text-sm text-muted-foreground">Page</label>
+                  <input
+                    type="number"
+                    min={0}
+                    class={inputClass}
+                    placeholder="0"
+                    value={draft.currentPage}
+                    onInput={(e) => edit("currentPage", (e.target as HTMLInputElement).value)}
+                  />
+                  <span class="text-muted-foreground">/</span>
+                  <input
+                    type="number"
+                    min={1}
+                    class={inputClass}
+                    placeholder="Total"
+                    value={draft.totalPages}
+                    onInput={(e) => edit("totalPages", (e.target as HTMLInputElement).value)}
+                  />
+                </div>
+                <details class="mt-3">
+                  <summary class="cursor-pointer text-sm text-muted-foreground hover:text-foreground">
+                    More options (chapters, manual %)
+                  </summary>
+                  <div class="mt-3 space-y-3">
+                    <div class="flex items-center gap-2">
+                      <label class="text-sm text-muted-foreground">Chapter</label>
+                      <input
+                        type="number"
+                        min={1}
+                        class={inputClass}
+                        placeholder="0"
+                        value={draft.currentChapter}
+                        onInput={(e) =>
+                          edit("currentChapter", (e.target as HTMLInputElement).value)
+                        }
+                      />
+                      <span class="text-muted-foreground">/</span>
+                      <input
+                        type="number"
+                        min={1}
+                        class={inputClass}
+                        placeholder="Total"
+                        value={draft.totalChapters}
+                        onInput={(e) => edit("totalChapters", (e.target as HTMLInputElement).value)}
+                      />
+                    </div>
+                    <div class="flex items-center gap-2">
+                      <label class="text-sm text-muted-foreground">Percent</label>
+                      <input
+                        type="number"
+                        min={0}
+                        max={100}
+                        class={inputClass}
+                        placeholder="Auto"
+                        value={draft.percent}
+                        onInput={(e) => edit("percent", (e.target as HTMLInputElement).value)}
+                      />
+                      <span class="text-xs text-muted-foreground">
+                        Auto-fills from pages or chapters
+                      </span>
+                    </div>
+                  </div>
+                </details>
+              </>
+            )}
+          </div>
+
+          {view && (
+            <div>
+              <label class="mb-2 block text-sm font-semibold text-foreground">Reading Dates</label>
+              <div class="flex flex-wrap items-center gap-4">
+                <div class="flex items-center gap-2">
+                  <label class="text-sm text-muted-foreground">Started</label>
+                  <input
+                    type="date"
+                    class={dateClass}
+                    value={draft.startedAt}
+                    onInput={(e) => edit("startedAt", (e.target as HTMLInputElement).value)}
+                  />
+                </div>
+                <div class="flex items-center gap-2">
+                  <label class="text-sm text-muted-foreground">Finished</label>
+                  <input
+                    type="date"
+                    class={dateClass}
+                    value={draft.finishedAt}
+                    onInput={(e) => edit("finishedAt", (e.target as HTMLInputElement).value)}
+                  />
+                </div>
+              </div>
+            </div>
+          )}
+
+          <div class="flex items-center gap-3">
+            <button
+              type="submit"
+              class="btn btn-primary w-full transition-[scale] duration-150 active:scale-[0.96] sm:w-auto"
+              aria-busy={pending > 0 ? "true" : "false"}
+            >
+              {pending > 0 ? "Saving…" : "Save"}
+            </button>
+            <span
+              class={`text-sm text-muted-foreground transition-opacity duration-300 ${justSaved ? "opacity-100" : "opacity-0"}`}
+              aria-live="polite"
+            >
+              Saved
+            </span>
+          </div>
+        </div>
+      </form>
+
+      {previousReads.length > 0 && (
+        <div>
+          <p class="mb-2 block text-sm font-semibold text-foreground">Previously Read</p>
+          <ul class="space-y-3 text-sm text-muted-foreground">
+            {[...previousReads]
+              .sort((a, b) => new Date(b.finishedAt).getTime() - new Date(a.finishedAt).getTime())
+              .map((r, i) => {
+                const fin = new Date(r.finishedAt);
+                const start = r.startedAt ? new Date(r.startedAt) : null;
+                return (
+                  <li key={`${r.finishedAt}-${i}`} style={{ fontVariantNumeric: "tabular-nums" }}>
+                    <span class="text-foreground">
+                      {start
+                        ? `${format(start, "MMM d, yyyy")} – ${format(fin, "MMM d, yyyy")}`
+                        : format(fin, "MMM d, yyyy")}
+                    </span>
+                  </li>
+                );
+              })}
+          </ul>
+        </div>
+      )}
+
+      {view && (
+        <div class="border-t border-border pt-4">
+          <button
+            type="button"
+            class="min-h-10 inline-flex items-center cursor-pointer text-xs text-muted-foreground hover:text-destructive"
+            onClick={() => dialogRef.current?.showModal()}
+          >
+            Remove from library
+          </button>
+          <dialog
+            ref={dialogRef}
+            class="fixed top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 rounded-lg border border-border bg-card p-6 text-card-foreground shadow-lg backdrop:bg-black/50"
+          >
+            <h3 class="mb-2 text-lg font-semibold">Remove book?</h3>
+            <p class="mb-4 text-sm text-muted-foreground" style={{ textWrap: "pretty" }}>
+              This will remove "{props.title}" from your library. This cannot be undone.
+            </p>
+            <div class="flex justify-end gap-2">
+              <button
+                type="button"
+                class="btn btn-ghost"
+                onClick={() => dialogRef.current?.close()}
+              >
+                Cancel
+              </button>
+              <button
+                type="button"
+                class="btn btn-destructive"
+                onClick={async () => {
+                  const ok = await store.remove();
+                  dialogRef.current?.close();
+                  if (ok) {
+                    setTouched(new Set());
+                    setDraft(draftFrom(null, props.numPages));
+                  }
+                }}
+              >
+                Remove
+              </button>
+            </div>
+          </dialog>
+        </div>
+      )}
+    </div>
+  );
+};

--- a/src/client/components/book/BookActivityPanel.tsx
+++ b/src/client/components/book/BookActivityPanel.tsx
@@ -154,11 +154,25 @@ export const BookActivityPanel: FC<{ store: UserBookStore; props: BookActionsPro
     // with the user's text on screen and a Save button that built an empty
     // payload and did nothing, with no way to retry but a reload.
     const sent = new Set(touched);
+    const sentValues = { ...draft };
     void store.update(fields, { explicitSave: true }).then((ok) => {
       if (!ok) return;
       setTouched((t) => {
         const next = new Set(t);
         for (const key of sent) next.delete(key);
+        return next;
+      });
+      // Re-sync the fields we just sent from what the server actually stored —
+      // an emptied review or date is not a clear, and leaving the box blank
+      // would misreport the record until some later change resynced it. A
+      // field edited again while the write was in flight keeps the new text.
+      const confirmedNow = store.getSnapshot().confirmed;
+      setDraft((d) => {
+        const fresh = draftFrom(confirmedNow, props.numPages);
+        const next = { ...d };
+        for (const key of sent) {
+          if (d[key] === sentValues[key]) next[key] = fresh[key];
+        }
         return next;
       });
     });
@@ -185,7 +199,13 @@ export const BookActivityPanel: FC<{ store: UserBookStore; props: BookActionsPro
             <div class="flex cursor-pointer">
               <StarRating
                 initialRating={view?.stars ?? 0}
-                onChange={(stars) => void store.update({ stars })}
+                onChange={(stars) => {
+                  // The leftmost sliver of the widget yields 0, and the server
+                  // reads 0 as "leave the rating alone" — sending it would
+                  // clear the stars on screen and then snap them back.
+                  if (!stars) return;
+                  void store.update({ stars });
+                }}
               />
             </div>
           </div>
@@ -255,7 +275,7 @@ export const BookActivityPanel: FC<{ store: UserBookStore; props: BookActionsPro
                   <input
                     id="progress-current-page"
                     type="number"
-                    min={0}
+                    min={1}
                     class={inputClass}
                     placeholder="0"
                     value={draft.currentPage}

--- a/src/client/components/book/BookActivityPanel.tsx
+++ b/src/client/components/book/BookActivityPanel.tsx
@@ -96,11 +96,14 @@ export const BookActivityPanel: FC<{ store: UserBookStore; props: BookActionsPro
 }) => {
   const { view, confirmed, pending, savedAt } = useUserBook(store);
   const [draft, setDraft] = useState<Draft>(() => draftFrom(view, props.numPages));
-  // Fields the user has edited since the last save. Everything else follows
-  // the server, so a status click that sets finishedAt shows up in the date
-  // box without wiping a half-written review.
+  // Edited-since-save fields. Everything else follows the server, so a status
+  // click's new date appears without wiping a half-written review.
   const [touched, setTouched] = useState<Set<keyof Draft>>(() => new Set());
   const dialogRef = useRef<HTMLDialogElement>(null);
+  const [removing, setRemoving] = useState(false);
+  /** Latest draft, for callbacks that must not close over a stale render. */
+  const draftRef = useRef<Draft>(draft);
+  draftRef.current = draft;
   const lastConfirmedCid = useRef(confirmed?.cid ?? null);
 
   useEffect(() => {
@@ -150,25 +153,25 @@ export const BookActivityPanel: FC<{ store: UserBookStore; props: BookActionsPro
       if (Object.values(progress).some((v) => v !== undefined)) fields.bookProgress = progress;
     }
     if (Object.keys(fields).length === 0 && view) return;
-    // Cleared only once the write lands. Clearing up front left a failed save
-    // with the user's text on screen and a Save button that built an empty
-    // payload and did nothing, with no way to retry but a reload.
+    // `touched` clears only once the write lands: clearing up front left a
+    // failed save showing the user's text with a Save button that did nothing.
     const sent = new Set(touched);
     const sentValues = { ...draft };
     void store.update(fields, { explicitSave: true }).then((ok) => {
       if (!ok) return;
+      // Re-sync sent fields from what was actually stored — an emptied review
+      // or date is not a clear. A field edited again mid-flight keeps its new
+      // text *and* its dirty flag, or that text becomes unsaveable.
+      const confirmedNow = store.getSnapshot().confirmed;
+      const fresh = draftFrom(confirmedNow, props.numPages);
+      const stillAsSent = (key: keyof Draft) =>
+        (draftRef.current ?? draft)[key] === sentValues[key];
       setTouched((t) => {
         const next = new Set(t);
-        for (const key of sent) next.delete(key);
+        for (const key of sent) if (stillAsSent(key)) next.delete(key);
         return next;
       });
-      // Re-sync the fields we just sent from what the server actually stored —
-      // an emptied review or date is not a clear, and leaving the box blank
-      // would misreport the record until some later change resynced it. A
-      // field edited again while the write was in flight keeps the new text.
-      const confirmedNow = store.getSnapshot().confirmed;
       setDraft((d) => {
-        const fresh = draftFrom(confirmedNow, props.numPages);
         const next = { ...d };
         for (const key of sent) {
           if (d[key] === sentValues[key]) next[key] = fresh[key];
@@ -200,9 +203,7 @@ export const BookActivityPanel: FC<{ store: UserBookStore; props: BookActionsPro
               <StarRating
                 initialRating={view?.stars ?? 0}
                 onChange={(stars) => {
-                  // The leftmost sliver of the widget yields 0, and the server
-                  // reads 0 as "leave the rating alone" — sending it would
-                  // clear the stars on screen and then snap them back.
+                  // The server reads 0 as "leave the rating alone".
                   if (!stars) return;
                   void store.update({ stars });
                 }}
@@ -453,8 +454,11 @@ export const BookActivityPanel: FC<{ store: UserBookStore; props: BookActionsPro
               <button
                 type="button"
                 class="btn btn-destructive"
+                disabled={removing}
                 onClick={async () => {
+                  setRemoving(true);
                   const ok = await store.remove();
+                  setRemoving(false);
                   dialogRef.current?.close();
                   if (ok) {
                     setTouched(new Set());
@@ -462,7 +466,7 @@ export const BookActivityPanel: FC<{ store: UserBookStore; props: BookActionsPro
                   }
                 }}
               >
-                Remove
+                {removing ? "Removing…" : "Remove"}
               </button>
             </div>
           </dialog>

--- a/src/client/components/book/BookActivityPanel.tsx
+++ b/src/client/components/book/BookActivityPanel.tsx
@@ -149,9 +149,19 @@ export const BookActivityPanel: FC<{ store: UserBookStore; props: BookActionsPro
       };
       if (Object.values(progress).some((v) => v !== undefined)) fields.bookProgress = progress;
     }
-    setTouched(new Set());
     if (Object.keys(fields).length === 0 && view) return;
-    void store.update(fields, { explicitSave: true });
+    // Cleared only once the write lands. Clearing up front left a failed save
+    // with the user's text on screen and a Save button that built an empty
+    // payload and did nothing, with no way to retry but a reload.
+    const sent = new Set(touched);
+    void store.update(fields, { explicitSave: true }).then((ok) => {
+      if (!ok) return;
+      setTouched((t) => {
+        const next = new Set(t);
+        for (const key of sent) next.delete(key);
+        return next;
+      });
+    });
   };
 
   const justSaved = savedAt !== null && Date.now() - savedAt < 2500;
@@ -239,8 +249,11 @@ export const BookActivityPanel: FC<{ store: UserBookStore; props: BookActionsPro
                   </div>
                 )}
                 <div class="flex items-center gap-2">
-                  <label class="text-sm text-muted-foreground">Page</label>
+                  <label class="text-sm text-muted-foreground" htmlFor="progress-current-page">
+                    Page
+                  </label>
                   <input
+                    id="progress-current-page"
                     type="number"
                     min={0}
                     class={inputClass}
@@ -250,6 +263,8 @@ export const BookActivityPanel: FC<{ store: UserBookStore; props: BookActionsPro
                   />
                   <span class="text-muted-foreground">/</span>
                   <input
+                    id="progress-total-pages"
+                    aria-label="Total pages"
                     type="number"
                     min={1}
                     class={inputClass}
@@ -264,8 +279,14 @@ export const BookActivityPanel: FC<{ store: UserBookStore; props: BookActionsPro
                   </summary>
                   <div class="mt-3 space-y-3">
                     <div class="flex items-center gap-2">
-                      <label class="text-sm text-muted-foreground">Chapter</label>
+                      <label
+                        class="text-sm text-muted-foreground"
+                        htmlFor="progress-current-chapter"
+                      >
+                        Chapter
+                      </label>
                       <input
+                        id="progress-current-chapter"
                         type="number"
                         min={1}
                         class={inputClass}
@@ -277,6 +298,8 @@ export const BookActivityPanel: FC<{ store: UserBookStore; props: BookActionsPro
                       />
                       <span class="text-muted-foreground">/</span>
                       <input
+                        id="progress-total-chapters"
+                        aria-label="Total chapters"
                         type="number"
                         min={1}
                         class={inputClass}
@@ -286,8 +309,11 @@ export const BookActivityPanel: FC<{ store: UserBookStore; props: BookActionsPro
                       />
                     </div>
                     <div class="flex items-center gap-2">
-                      <label class="text-sm text-muted-foreground">Percent</label>
+                      <label class="text-sm text-muted-foreground" htmlFor="progress-percent">
+                        Percent
+                      </label>
                       <input
+                        id="progress-percent"
                         type="number"
                         min={0}
                         max={100}
@@ -311,8 +337,11 @@ export const BookActivityPanel: FC<{ store: UserBookStore; props: BookActionsPro
               <label class="mb-2 block text-sm font-semibold text-foreground">Reading Dates</label>
               <div class="flex flex-wrap items-center gap-4">
                 <div class="flex items-center gap-2">
-                  <label class="text-sm text-muted-foreground">Started</label>
+                  <label class="text-sm text-muted-foreground" htmlFor="reading-started-at">
+                    Started
+                  </label>
                   <input
+                    id="reading-started-at"
                     type="date"
                     class={dateClass}
                     value={draft.startedAt}
@@ -320,8 +349,11 @@ export const BookActivityPanel: FC<{ store: UserBookStore; props: BookActionsPro
                   />
                 </div>
                 <div class="flex items-center gap-2">
-                  <label class="text-sm text-muted-foreground">Finished</label>
+                  <label class="text-sm text-muted-foreground" htmlFor="reading-finished-at">
+                    Finished
+                  </label>
                   <input
+                    id="reading-finished-at"
                     type="date"
                     class={dateClass}
                     value={draft.finishedAt}

--- a/src/client/components/book/index.tsx
+++ b/src/client/components/book/index.tsx
@@ -1,0 +1,20 @@
+import { render } from "hono/jsx/dom";
+
+import { BookActionRow } from "./BookActionRow";
+import { BookActivityPanel, BookUserTimestamp } from "./BookActivityPanel";
+import { createUserBookStore, type BookActionsProps } from "./userBookStore";
+
+/**
+ * Three mounts, one store. The status/owned buttons sit in the hero card and
+ * the activity form two cards down, so they cannot share a root; the server
+ * markup inside each mount is the pre-hydration paint and is replaced here.
+ */
+export function mountBookIslands(props: BookActionsProps) {
+  const store = createUserBookStore(props);
+  const actions = document.getElementById("mount-book-actions");
+  const timestamp = document.getElementById("mount-book-timestamp");
+  const activity = document.getElementById("mount-book-activity");
+  if (actions) render(<BookActionRow store={store} />, actions);
+  if (timestamp) render(<BookUserTimestamp store={store} />, timestamp);
+  if (activity) render(<BookActivityPanel store={store} props={props} />, activity);
+}

--- a/src/client/components/book/userBookStore.test.ts
+++ b/src/client/components/book/userBookStore.test.ts
@@ -135,7 +135,7 @@ describe("createUserBookStore", () => {
     expect(s.view?.stars).toBe(8);
   });
 
-  it("waits for queued writes before deleting, and refuses writes afterwards", async () => {
+  it("waits for queued writes before deleting", async () => {
     const calls: string[] = [];
     let releaseUpdate: (() => void) | null = null;
     const updateStarted = new Promise<void>((r) => (releaseUpdate = r));
@@ -156,10 +156,47 @@ describe("createUserBookStore", () => {
     // The DELETE must not overtake the update — that write would re-create the book.
     expect(calls).toEqual(["POST /api/update-book", "DELETE /books/bk_x"]);
     expect(store.getSnapshot().view).toBeNull();
+  });
 
-    expect(await store.update({ stars: 2 })).toBe(false);
-    expect(calls).toHaveLength(2);
+  it("refuses a write started while the delete is in flight", async () => {
+    const calls: string[] = [];
+    let releaseDelete: (() => void) | null = null;
+    const deleteStarted = new Promise<void>((r) => (releaseDelete = r));
+    let unblock: (() => void) | null = null;
+    const held = new Promise<void>((r) => (unblock = r));
+    globalThis.fetch = (async (url: string, init: RequestInit) => {
+      calls.push(`${init.method} ${url}`);
+      if (init.method === "DELETE") {
+        (releaseDelete as unknown as () => void)();
+        await held;
+        return jsonOk({ success: true });
+      }
+      return jsonOk({ success: true, userBook: view({ stars: 8 }) });
+    }) as unknown as typeof fetch;
+
+    const store = createUserBookStore(props);
+    const removal = store.remove();
+    await deleteStarted;
+    // A click landing between the DELETE going out and coming back: the server
+    // would create the record again, so the store must not send it.
+    expect(await store.update({ stars: 8 })).toBe(false);
+    (unblock as unknown as () => void)();
+    expect(await removal).toBe(true);
+    expect(calls).toEqual(["DELETE /books/bk_x"]);
     expect(store.getSnapshot().view).toBeNull();
+  });
+
+  it("allows the book to be added again after a successful removal", async () => {
+    globalThis.fetch = (async (_url: string, init: RequestInit) => {
+      if (init.method === "DELETE") return jsonOk({ success: true });
+      return jsonOk({ success: true, userBook: view({ status: STATUS.WANT_TO_READ }) });
+    }) as unknown as typeof fetch;
+    const store = createUserBookStore(props);
+    expect(await store.remove()).toBe(true);
+    expect(store.getSnapshot().view).toBeNull();
+
+    expect(await store.update({ status: STATUS.WANT_TO_READ })).toBe(true);
+    expect(store.getSnapshot().view?.status).toBe(STATUS.WANT_TO_READ);
   });
 
   it("reports a failed removal without clearing the book", async () => {

--- a/src/client/components/book/userBookStore.test.ts
+++ b/src/client/components/book/userBookStore.test.ts
@@ -1,7 +1,7 @@
-import { describe, expect, it } from "bun:test";
+import { afterEach, describe, expect, it } from "bun:test";
 
 import type { UserBookView } from "../../../utils/userBookView";
-import { STATUS, applyOptimistic } from "./userBookStore";
+import { STATUS, applyOptimistic, createUserBookStore } from "./userBookStore";
 
 const props = { hiveId: "bk_x", title: "Dune", authors: "Frank Herbert" };
 
@@ -83,5 +83,90 @@ describe("applyOptimistic", () => {
   it("cannot clear a review with an empty string (matches the server)", () => {
     const next = applyOptimistic(view({ review: "Good." }), { review: "" }, props);
     expect(next.review).toBe("Good.");
+  });
+});
+
+describe("createUserBookStore", () => {
+  const props = {
+    hiveId: "bk_x",
+    title: "Dune",
+    authors: "Frank Herbert",
+    numPages: null,
+    userBook: view(),
+  };
+  const realFetch = globalThis.fetch;
+  afterEach(() => {
+    globalThis.fetch = realFetch;
+  });
+
+  const jsonOk = (body: unknown) =>
+    new Response(JSON.stringify(body), { status: 200, headers: { "content-type": "text/plain" } });
+
+  it("rolls the view back to the last confirmed state when a write fails", async () => {
+    globalThis.fetch = (async () =>
+      jsonOk({ success: false, message: "nope" })) as unknown as typeof fetch;
+    const store = createUserBookStore(props);
+    const ok = await store.update({ status: STATUS.FINISHED });
+    expect(ok).toBe(false);
+    const s = store.getSnapshot();
+    expect(s.view?.status).toBe(STATUS.WANT_TO_READ);
+    expect(s.pending).toBe(0);
+    expect(s.error).toBeTruthy();
+  });
+
+  it("keeps queued writes in order and only the last response replaces the view", async () => {
+    const seen: string[] = [];
+    globalThis.fetch = (async (_url: string, init: RequestInit) => {
+      const body = JSON.parse(String(init.body)) as { status?: string; stars?: number };
+      seen.push(body.status ?? `stars:${body.stars}`);
+      return jsonOk({
+        success: true,
+        userBook: view({ status: body.status ?? STATUS.WANT_TO_READ, stars: body.stars ?? null }),
+      });
+    }) as unknown as typeof fetch;
+    const store = createUserBookStore(props);
+    const a = store.update({ status: STATUS.READING });
+    const b = store.update({ stars: 8 });
+    expect(store.getSnapshot().pending).toBe(2);
+    await Promise.all([a, b]);
+    expect(seen).toEqual([STATUS.READING, "stars:8"]);
+    const s = store.getSnapshot();
+    expect(s.pending).toBe(0);
+    expect(s.view?.stars).toBe(8);
+  });
+
+  it("waits for queued writes before deleting, and refuses writes afterwards", async () => {
+    const calls: string[] = [];
+    let releaseUpdate: (() => void) | null = null;
+    const updateStarted = new Promise<void>((r) => (releaseUpdate = r));
+    globalThis.fetch = (async (url: string, init: RequestInit) => {
+      calls.push(`${init.method} ${url}`);
+      if (String(url).includes("/api/update-book")) {
+        (releaseUpdate as unknown as () => void)();
+        await new Promise((r) => setTimeout(r, 20));
+        return jsonOk({ success: true, userBook: view({ stars: 8 }) });
+      }
+      return jsonOk({ success: true });
+    }) as unknown as typeof fetch;
+
+    const store = createUserBookStore(props);
+    void store.update({ stars: 8 });
+    await updateStarted;
+    expect(await store.remove()).toBe(true);
+    // The DELETE must not overtake the update — that write would re-create the book.
+    expect(calls).toEqual(["POST /api/update-book", "DELETE /books/bk_x"]);
+    expect(store.getSnapshot().view).toBeNull();
+
+    expect(await store.update({ stars: 2 })).toBe(false);
+    expect(calls).toHaveLength(2);
+    expect(store.getSnapshot().view).toBeNull();
+  });
+
+  it("reports a failed removal without clearing the book", async () => {
+    globalThis.fetch = (async () => jsonOk({ success: false })) as unknown as typeof fetch;
+    const store = createUserBookStore(props);
+    expect(await store.remove()).toBe(false);
+    expect(store.getSnapshot().view).not.toBeNull();
+    expect(store.getSnapshot().error).toBeTruthy();
   });
 });

--- a/src/client/components/book/userBookStore.test.ts
+++ b/src/client/components/book/userBookStore.test.ts
@@ -80,6 +80,51 @@ describe("applyOptimistic", () => {
     expect(next.bookProgress?.currentPage).toBe(300);
   });
 
+  it("stamps no date when the payload asserts no status", () => {
+    // A stars/owned/review write carries no status, and the server leaves the
+    // dates alone. Guessing from the record's status painted a "Started just
+    // now" that the response then took back.
+    const next = applyOptimistic(
+      view({ status: STATUS.READING, startedAt: null }),
+      { stars: 8 },
+      props,
+    );
+    expect(next.startedAt).toBeNull();
+    expect(next.status).toBe(STATUS.READING);
+  });
+
+  it("does not restamp the start date of a book already reading", () => {
+    const next = applyOptimistic(
+      view({ status: STATUS.READING, startedAt: "2026-03-01T00:00:00.000Z" }),
+      { status: STATUS.READING, bookProgress: { currentPage: 12 } },
+      props,
+    );
+    expect(next.startedAt).toBe("2026-03-01T00:00:00.000Z");
+  });
+
+  it("does not downgrade a finished book when only a date is edited", () => {
+    const next = applyOptimistic(
+      view({
+        status: STATUS.FINISHED,
+        startedAt: "2026-02-01T00:00:00.000Z",
+        finishedAt: "2026-03-01T00:00:00.000Z",
+      }),
+      { startedAt: "2026-02-05" },
+      props,
+    );
+    expect(next.status).toBe(STATUS.FINISHED);
+    expect(next.finishedAt).toBe("2026-03-01T00:00:00.000Z");
+  });
+
+  it("stamps a fresh finish date when a book is finished again", () => {
+    const next = applyOptimistic(
+      view({ status: STATUS.READING, finishedAt: "2020-02-01T00:00:00.000Z" }),
+      { status: STATUS.FINISHED },
+      props,
+    );
+    expect(next.finishedAt).not.toBe("2020-02-01T00:00:00.000Z");
+  });
+
   it("cannot clear a review with an empty string (matches the server)", () => {
     const next = applyOptimistic(view({ review: "Good." }), { review: "" }, props);
     expect(next.review).toBe("Good.");

--- a/src/client/components/book/userBookStore.test.ts
+++ b/src/client/components/book/userBookStore.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from "bun:test";
+
+import type { UserBookView } from "../../../utils/userBookView";
+import { STATUS, applyOptimistic } from "./userBookStore";
+
+const props = { hiveId: "bk_x", title: "Dune", authors: "Frank Herbert" };
+
+const view = (over: Partial<UserBookView> = {}): UserBookView => ({
+  uri: "at://did/buzz.bookhive.book/1",
+  cid: "cid1",
+  hiveId: "bk_x" as UserBookView["hiveId"],
+  title: "Dune",
+  authors: "Frank Herbert",
+  status: STATUS.WANT_TO_READ,
+  owned: true,
+  stars: null,
+  review: null,
+  startedAt: null,
+  finishedAt: null,
+  bookProgress: null,
+  previousReads: null,
+  createdAt: "2026-01-01T00:00:00.000Z",
+  indexedAt: "2026-01-01T00:00:00.000Z",
+  ...over,
+});
+
+describe("applyOptimistic", () => {
+  it("builds a provisional view for a first add, owned by default", () => {
+    const next = applyOptimistic(null, { status: STATUS.WANT_TO_READ }, props);
+    expect(next.status).toBe(STATUS.WANT_TO_READ);
+    expect(next.owned).toBe(true);
+    expect(next.title).toBe("Dune");
+  });
+
+  it("stamps finishedAt when marking as read, like the server will", () => {
+    const next = applyOptimistic(view(), { status: STATUS.FINISHED }, props);
+    expect(next.status).toBe(STATUS.FINISHED);
+    expect(next.finishedAt).toBeTruthy();
+  });
+
+  it("rotates a finished read into previousReads on a re-read", () => {
+    const next = applyOptimistic(
+      view({
+        status: STATUS.FINISHED,
+        startedAt: "2026-02-01T00:00:00.000Z",
+        finishedAt: "2026-03-01T00:00:00.000Z",
+      }),
+      { status: STATUS.READING },
+      props,
+    );
+    expect(next.status).toBe(STATUS.READING);
+    expect(next.finishedAt).toBeNull();
+    expect(next.startedAt).not.toBe("2026-02-01T00:00:00.000Z");
+    expect(next.previousReads).toEqual([
+      { startedAt: "2026-02-01T00:00:00.000Z", finishedAt: "2026-03-01T00:00:00.000Z" },
+    ]);
+  });
+
+  it("infers reading from progress and finished from a finish date", () => {
+    const a = applyOptimistic(view({ status: null }), { bookProgress: { percent: 10 } }, props);
+    expect(a.status).toBe(STATUS.READING);
+    expect(a.bookProgress?.percent).toBe(10);
+
+    const b = applyOptimistic(
+      view({ status: STATUS.READING }),
+      { finishedAt: "2026-05-05" },
+      props,
+    );
+    expect(b.status).toBe(STATUS.FINISHED);
+    expect(b.finishedAt?.startsWith("2026-05-05")).toBe(true);
+  });
+
+  it("forces progress to 100% on a finished book", () => {
+    const next = applyOptimistic(
+      view({ bookProgress: { percent: 40, totalPages: 300, currentPage: 120, updatedAt: "x" } }),
+      { status: STATUS.FINISHED },
+      props,
+    );
+    expect(next.bookProgress?.percent).toBe(100);
+    expect(next.bookProgress?.currentPage).toBe(300);
+  });
+
+  it("cannot clear a review with an empty string (matches the server)", () => {
+    const next = applyOptimistic(view({ review: "Good." }), { review: "" }, props);
+    expect(next.review).toBe("Good.");
+  });
+});

--- a/src/client/components/book/userBookStore.ts
+++ b/src/client/components/book/userBookStore.ts
@@ -70,7 +70,10 @@ function nowIso() {
 /** Mirrors `dateInputToISO` on the server: a date input's value plus the current time of day. */
 function dateInputToIso(value: string | undefined): string | null | undefined {
   if (value === undefined) return undefined;
-  if (value === "") return null;
+  // The server's `normalizeDate("")` yields undefined and the merge then keeps
+  // the recorded date, so an emptied box is a no-op, not a clear. Mirroring
+  // that here is what stops the UI from showing a clear that never happened.
+  if (value === "") return undefined;
   if (/^\d{4}-\d{2}-\d{2}$/.test(value)) {
     const [y, m, d] = value.split("-").map(Number) as [number, number, number];
     const now = new Date();
@@ -124,7 +127,9 @@ export function applyOptimistic(
     next.bookProgress = fields.bookProgress
       ? { ...fields.bookProgress, updatedAt: nowIso() }
       : null;
-    if (!fields.status && !base.status) status = STATUS.READING;
+    // `/api/update-book` forces READING on any progress write that carries no
+    // status of its own — including on an abandoned book.
+    if (!fields.status) status = STATUS.READING;
   }
   if (startedAt && (!status || status === STATUS.WANT_TO_READ)) status = STATUS.READING;
   if (finishedAt && (!status || status === STATUS.WANT_TO_READ || status === STATUS.READING)) {
@@ -173,10 +178,13 @@ export function createUserBookStore(props: BookActionsProps) {
     listeners.forEach((l) => l());
   };
   let queue: Promise<unknown> = Promise.resolve();
-  // Set once the book has been removed. `updateBookRecord` *creates* a record
-  // when no `user_book` row exists, so a write that lands after the DELETE
-  // would put the book back on the user's PDS and in their library.
-  let removed = false;
+  // Set synchronously for the whole removal, because `updateBookRecord`
+  // *creates* a record when no `user_book` row exists: a write that starts
+  // during the DELETE would put the book back on the user's PDS. Awaiting the
+  // queue is not enough — `queue` is reassigned by every `update`, so a click
+  // during the round trip would slip past it. Cleared when the removal
+  // settles, so re-adding the book afterwards still works.
+  let deleting = false;
 
   async function send(fields: UpdateFields, explicitSave: boolean): Promise<boolean> {
     // Everything runs through one queue and `pending` only drops when a send
@@ -230,7 +238,7 @@ export function createUserBookStore(props: BookActionsProps) {
     getSnapshot: () => state,
     /** Apply at once, send in order. Resolves to whether the write landed. */
     update: (fields: UpdateFields, { explicitSave = false } = {}): Promise<boolean> => {
-      if (removed) return Promise.resolve(false);
+      if (deleting) return Promise.resolve(false);
       set({
         view: applyOptimistic(state.view, fields, props),
         pending: state.pending + 1,
@@ -241,24 +249,31 @@ export function createUserBookStore(props: BookActionsProps) {
       return queue as Promise<boolean>;
     },
     remove: async (): Promise<boolean> => {
+      if (deleting) return false;
+      deleting = true;
       set({ error: null });
-      // Queued writes first, for the reason above: a delete that overtakes
-      // them would be undone by whichever one lands last.
+      // Queued writes first: a delete that overtakes them would be undone by
+      // whichever one lands last.
       await queue.catch(() => {});
+      const abort = new AbortController();
+      const timer = setTimeout(() => abort.abort(), REQUEST_TIMEOUT_MS);
       try {
         const res = await fetch(`/books/${props.hiveId}`, {
           method: "DELETE",
           headers: { accept: "application/json" },
+          signal: abort.signal,
         });
         const body = (await res.json().catch(() => ({}))) as { success?: boolean };
         if (!res.ok || !body.success) throw new Error(`Could not remove (${res.status})`);
-        removed = true;
         set({ view: null, confirmed: null });
         return true;
       } catch (e) {
         console.error("[book] remove failed:", e);
         set({ error: "The book could not be removed. Please try again." });
         return false;
+      } finally {
+        clearTimeout(timer);
+        deleting = false;
       }
     },
     dismissError: () => {

--- a/src/client/components/book/userBookStore.ts
+++ b/src/client/components/book/userBookStore.ts
@@ -60,6 +60,9 @@ export type StoreState = {
 
 export type UserBookStore = ReturnType<typeof createUserBookStore>;
 
+/** Bounds how long one mutation can hold the queue. */
+const REQUEST_TIMEOUT_MS = 20_000;
+
 function nowIso() {
   return new Date().toISOString();
 }
@@ -170,13 +173,23 @@ export function createUserBookStore(props: BookActionsProps) {
     listeners.forEach((l) => l());
   };
   let queue: Promise<unknown> = Promise.resolve();
+  // Set once the book has been removed. `updateBookRecord` *creates* a record
+  // when no `user_book` row exists, so a write that lands after the DELETE
+  // would put the book back on the user's PDS and in their library.
+  let removed = false;
 
-  async function send(fields: UpdateFields, explicitSave: boolean) {
+  async function send(fields: UpdateFields, explicitSave: boolean): Promise<boolean> {
+    // Everything runs through one queue and `pending` only drops when a send
+    // settles, so a request the browser never times out would wedge the Save
+    // button and block every later change on the page.
+    const abort = new AbortController();
+    const timer = setTimeout(() => abort.abort(), REQUEST_TIMEOUT_MS);
     try {
       const res = await fetch("/api/update-book", {
         method: "POST",
         headers: { "content-type": "application/json", accept: "application/json" },
         body: JSON.stringify({ hiveId: props.hiveId, ...fields }),
+        signal: abort.signal,
       });
       const body = (await res.json().catch(() => ({}))) as {
         success?: boolean;
@@ -193,6 +206,7 @@ export function createUserBookStore(props: BookActionsProps) {
         view: pending === 0 ? body.userBook : state.view,
         savedAt: explicitSave ? Date.now() : state.savedAt,
       });
+      return true;
     } catch (e) {
       // The server's message names CIDs and lexicon paths; that belongs in
       // the console, not next to the button.
@@ -202,6 +216,9 @@ export function createUserBookStore(props: BookActionsProps) {
         view: state.confirmed,
         error: "That change could not be saved. Your library was left as it was.",
       });
+      return false;
+    } finally {
+      clearTimeout(timer);
     }
   }
 
@@ -211,8 +228,9 @@ export function createUserBookStore(props: BookActionsProps) {
       return () => listeners.delete(listener);
     },
     getSnapshot: () => state,
-    /** Apply at once, send in order. Resolves when this write has settled. */
-    update: (fields: UpdateFields, { explicitSave = false } = {}): Promise<void> => {
+    /** Apply at once, send in order. Resolves to whether the write landed. */
+    update: (fields: UpdateFields, { explicitSave = false } = {}): Promise<boolean> => {
+      if (removed) return Promise.resolve(false);
       set({
         view: applyOptimistic(state.view, fields, props),
         pending: state.pending + 1,
@@ -220,10 +238,13 @@ export function createUserBookStore(props: BookActionsProps) {
       });
       const run = () => send(fields, explicitSave);
       queue = queue.then(run, run);
-      return queue as Promise<void>;
+      return queue as Promise<boolean>;
     },
     remove: async (): Promise<boolean> => {
       set({ error: null });
+      // Queued writes first, for the reason above: a delete that overtakes
+      // them would be undone by whichever one lands last.
+      await queue.catch(() => {});
       try {
         const res = await fetch(`/books/${props.hiveId}`, {
           method: "DELETE",
@@ -231,6 +252,7 @@ export function createUserBookStore(props: BookActionsProps) {
         });
         const body = (await res.json().catch(() => ({}))) as { success?: boolean };
         if (!res.ok || !body.success) throw new Error(`Could not remove (${res.status})`);
+        removed = true;
         set({ view: null, confirmed: null });
         return true;
       } catch (e) {

--- a/src/client/components/book/userBookStore.ts
+++ b/src/client/components/book/userBookStore.ts
@@ -1,16 +1,11 @@
 /**
- * Client state for "my relationship to this book" on /books/:id.
+ * Client state for "my relationship to this book" on /books/:id, shared by the
+ * three islands. Changes apply optimistically and are replaced by the server's
+ * `UserBookView`; on failure `view` snaps back to `confirmed`.
  *
- * One store per page, shared by the islands in the hero card and the
- * activity card. Every change is applied to `view` at once, then sent; the
- * server's `UserBookView` replaces `view` when it lands, which is how
- * server-side inference (auto dates, re-read rotation, 100% on finish) shows
- * up without a reload. On failure `view` snaps back to `confirmed`.
- *
- * Mutations are serialised: the server holds a per-user lock and the merge
- * is CAS'd on the previous write's cid, so two in-flight writes would only
- * race each other. While later writes are still queued a response does not
- * overwrite `view` — it would briefly undo what the user just did.
+ * Writes are serialised because the server CASes each one on the previous
+ * write's cid, and a response never overwrites `view` while later writes are
+ * still queued — it would undo what the user just did.
  */
 import type { UserBookView } from "../../../utils/userBookView";
 
@@ -67,12 +62,10 @@ function nowIso() {
   return new Date().toISOString();
 }
 
-/** Mirrors `dateInputToISO` on the server: a date input's value plus the current time of day. */
+/** Mirrors the server's `dateInputToISO`. */
 function dateInputToIso(value: string | undefined): string | null | undefined {
   if (value === undefined) return undefined;
-  // The server's `normalizeDate("")` yields undefined and the merge then keeps
-  // the recorded date, so an emptied box is a no-op, not a clear. Mirroring
-  // that here is what stops the UI from showing a clear that never happened.
+  // An emptied box is a no-op server-side, not a clear.
   if (value === "") return undefined;
   if (/^\d{4}-\d{2}-\d{2}$/.test(value)) {
     const [y, m, d] = value.split("-").map(Number) as [number, number, number];
@@ -84,11 +77,7 @@ function dateInputToIso(value: string | undefined): string | null | undefined {
   return value;
 }
 
-/**
- * The server's `inferBookStatusAndDates` + re-read rules, approximated so the
- * optimistic frame looks like the confirmed one will. The server's answer
- * always wins.
- */
+/** Mirrors the server's `inferBookStatusAndDates`; its answer always wins. */
 export function applyOptimistic(
   current: UserBookView | null,
   fields: UpdateFields,
@@ -122,21 +111,37 @@ export function applyOptimistic(
   if (startedAt !== undefined) next.startedAt = startedAt;
   if (finishedAt !== undefined) next.finishedAt = finishedAt;
 
-  let status = fields.status ?? base.status;
-  if (fields.bookProgress !== undefined) {
+  // `sent` is the status this payload asserts. A payload asserting none leaves
+  // the server's status and dates untouched, so guessing here paints a frame
+  // the response would take back.
+  let sent = fields.status;
+  if (fields.bookProgress !== undefined && !sent) {
     next.bookProgress = fields.bookProgress
       ? { ...fields.bookProgress, updatedAt: nowIso() }
       : null;
-    // `/api/update-book` forces READING on any progress write that carries no
-    // status of its own — including on an abandoned book.
-    if (!fields.status) status = STATUS.READING;
+    // `/api/update-book` stamps READING onto a statusless progress write.
+    sent = STATUS.READING;
+  } else if (fields.bookProgress !== undefined) {
+    next.bookProgress = fields.bookProgress
+      ? { ...fields.bookProgress, updatedAt: nowIso() }
+      : null;
   }
-  if (startedAt && (!status || status === STATUS.WANT_TO_READ)) status = STATUS.READING;
-  if (finishedAt && (!status || status === STATUS.WANT_TO_READ || status === STATUS.READING)) {
-    status = STATUS.FINISHED;
+  const currentStatus = fields.status ?? base.status;
+  if (startedAt && (!currentStatus || currentStatus === STATUS.WANT_TO_READ)) {
+    sent = STATUS.READING;
   }
+  if (
+    finishedAt &&
+    (!currentStatus || currentStatus === STATUS.WANT_TO_READ || currentStatus === STATUS.READING)
+  ) {
+    sent = STATUS.FINISHED;
+  }
+  const status = sent ?? base.status;
 
   const isReread = fields.status === STATUS.READING && base.status === STATUS.FINISHED;
+  // Only a real transition stamps a date, matching the server.
+  const alreadyReading = base.status === STATUS.READING && !!base.startedAt;
+  const alreadyFinished = base.status === STATUS.FINISHED && !!base.finishedAt;
   if (isReread) {
     if (base.finishedAt) {
       next.previousReads = [
@@ -146,9 +151,9 @@ export function applyOptimistic(
     }
     next.startedAt = nowIso();
     next.finishedAt = null;
-  } else if (status === STATUS.READING && !next.startedAt) {
+  } else if (sent === STATUS.READING && !fields.startedAt && !alreadyReading) {
     next.startedAt = nowIso();
-  } else if (status === STATUS.FINISHED && !next.finishedAt) {
+  } else if (sent === STATUS.FINISHED && !fields.finishedAt && !alreadyFinished) {
     next.finishedAt = nowIso();
   }
 
@@ -178,18 +183,13 @@ export function createUserBookStore(props: BookActionsProps) {
     listeners.forEach((l) => l());
   };
   let queue: Promise<unknown> = Promise.resolve();
-  // Set synchronously for the whole removal, because `updateBookRecord`
-  // *creates* a record when no `user_book` row exists: a write that starts
-  // during the DELETE would put the book back on the user's PDS. Awaiting the
-  // queue is not enough — `queue` is reassigned by every `update`, so a click
-  // during the round trip would slip past it. Cleared when the removal
-  // settles, so re-adding the book afterwards still works.
+  // `updateBookRecord` creates a record when no row exists, so a write starting
+  // during the DELETE would put the book back. Awaiting `queue` is not enough:
+  // every `update` reassigns it. Cleared on settle, so re-adding still works.
   let deleting = false;
 
   async function send(fields: UpdateFields, explicitSave: boolean): Promise<boolean> {
-    // Everything runs through one queue and `pending` only drops when a send
-    // settles, so a request the browser never times out would wedge the Save
-    // button and block every later change on the page.
+    // A request the browser never times out would wedge the queue.
     const abort = new AbortController();
     const timer = setTimeout(() => abort.abort(), REQUEST_TIMEOUT_MS);
     try {
@@ -216,8 +216,7 @@ export function createUserBookStore(props: BookActionsProps) {
       });
       return true;
     } catch (e) {
-      // The server's message names CIDs and lexicon paths; that belongs in
-      // the console, not next to the button.
+      // The server's message names CIDs and lexicon paths.
       console.error("[book] save failed:", e);
       set({
         pending: state.pending - 1,
@@ -252,8 +251,6 @@ export function createUserBookStore(props: BookActionsProps) {
       if (deleting) return false;
       deleting = true;
       set({ error: null });
-      // Queued writes first: a delete that overtakes them would be undone by
-      // whichever one lands last.
       await queue.catch(() => {});
       const abort = new AbortController();
       const timer = setTimeout(() => abort.abort(), REQUEST_TIMEOUT_MS);

--- a/src/client/components/book/userBookStore.ts
+++ b/src/client/components/book/userBookStore.ts
@@ -1,0 +1,246 @@
+/**
+ * Client state for "my relationship to this book" on /books/:id.
+ *
+ * One store per page, shared by the islands in the hero card and the
+ * activity card. Every change is applied to `view` at once, then sent; the
+ * server's `UserBookView` replaces `view` when it lands, which is how
+ * server-side inference (auto dates, re-read rotation, 100% on finish) shows
+ * up without a reload. On failure `view` snaps back to `confirmed`.
+ *
+ * Mutations are serialised: the server holds a per-user lock and the merge
+ * is CAS'd on the previous write's cid, so two in-flight writes would only
+ * race each other. While later writes are still queued a response does not
+ * overwrite `view` — it would briefly undo what the user just did.
+ */
+import type { UserBookView } from "../../../utils/userBookView";
+
+export const STATUS = {
+  FINISHED: "buzz.bookhive.defs#finished",
+  READING: "buzz.bookhive.defs#reading",
+  WANT_TO_READ: "buzz.bookhive.defs#wantToRead",
+  ABANDONED: "buzz.bookhive.defs#abandoned",
+} as const;
+
+export type BookProgressFields = {
+  percent?: number;
+  totalPages?: number;
+  currentPage?: number;
+  totalChapters?: number;
+  currentChapter?: number;
+};
+
+/** What `/api/update-book` accepts, minus `hiveId`. */
+export type UpdateFields = {
+  status?: string;
+  owned?: boolean;
+  stars?: number;
+  review?: string;
+  /** YYYY-MM-DD or "" to clear. */
+  startedAt?: string;
+  finishedAt?: string;
+  bookProgress?: BookProgressFields | null;
+};
+
+export type BookActionsProps = {
+  hiveId: string;
+  title: string;
+  authors: string;
+  numPages: number | null;
+  userBook: UserBookView | null;
+};
+
+export type StoreState = {
+  view: UserBookView | null;
+  confirmed: UserBookView | null;
+  pending: number;
+  error: string | null;
+  /** Set briefly after a successful explicit Save. */
+  savedAt: number | null;
+};
+
+export type UserBookStore = ReturnType<typeof createUserBookStore>;
+
+function nowIso() {
+  return new Date().toISOString();
+}
+
+/** Mirrors `dateInputToISO` on the server: a date input's value plus the current time of day. */
+function dateInputToIso(value: string | undefined): string | null | undefined {
+  if (value === undefined) return undefined;
+  if (value === "") return null;
+  if (/^\d{4}-\d{2}-\d{2}$/.test(value)) {
+    const [y, m, d] = value.split("-").map(Number) as [number, number, number];
+    const now = new Date();
+    return new Date(
+      Date.UTC(y, m - 1, d, now.getUTCHours(), now.getUTCMinutes(), now.getUTCSeconds()),
+    ).toISOString();
+  }
+  return value;
+}
+
+/**
+ * The server's `inferBookStatusAndDates` + re-read rules, approximated so the
+ * optimistic frame looks like the confirmed one will. The server's answer
+ * always wins.
+ */
+export function applyOptimistic(
+  current: UserBookView | null,
+  fields: UpdateFields,
+  props: Pick<BookActionsProps, "hiveId" | "title" | "authors">,
+): UserBookView {
+  const base: UserBookView = current ?? {
+    uri: "",
+    cid: "",
+    hiveId: props.hiveId as UserBookView["hiveId"],
+    title: props.title,
+    authors: props.authors,
+    status: null,
+    owned: true,
+    stars: null,
+    review: null,
+    startedAt: null,
+    finishedAt: null,
+    bookProgress: null,
+    previousReads: null,
+    createdAt: nowIso(),
+    indexedAt: nowIso(),
+  };
+  const next: UserBookView = { ...base };
+
+  if (fields.owned !== undefined) next.owned = fields.owned;
+  if (fields.stars !== undefined) next.stars = fields.stars || null;
+  if (fields.review !== undefined) next.review = fields.review || base.review;
+
+  const startedAt = dateInputToIso(fields.startedAt);
+  const finishedAt = dateInputToIso(fields.finishedAt);
+  if (startedAt !== undefined) next.startedAt = startedAt;
+  if (finishedAt !== undefined) next.finishedAt = finishedAt;
+
+  let status = fields.status ?? base.status;
+  if (fields.bookProgress !== undefined) {
+    next.bookProgress = fields.bookProgress
+      ? { ...fields.bookProgress, updatedAt: nowIso() }
+      : null;
+    if (!fields.status && !base.status) status = STATUS.READING;
+  }
+  if (startedAt && (!status || status === STATUS.WANT_TO_READ)) status = STATUS.READING;
+  if (finishedAt && (!status || status === STATUS.WANT_TO_READ || status === STATUS.READING)) {
+    status = STATUS.FINISHED;
+  }
+
+  const isReread = fields.status === STATUS.READING && base.status === STATUS.FINISHED;
+  if (isReread) {
+    if (base.finishedAt) {
+      next.previousReads = [
+        { startedAt: base.startedAt ?? undefined, finishedAt: base.finishedAt },
+        ...(base.previousReads ?? []),
+      ];
+    }
+    next.startedAt = nowIso();
+    next.finishedAt = null;
+  } else if (status === STATUS.READING && !next.startedAt) {
+    next.startedAt = nowIso();
+  } else if (status === STATUS.FINISHED && !next.finishedAt) {
+    next.finishedAt = nowIso();
+  }
+
+  if (status === STATUS.FINISHED && next.bookProgress) {
+    next.bookProgress = {
+      ...next.bookProgress,
+      percent: 100,
+      currentPage: next.bookProgress.totalPages ?? next.bookProgress.currentPage,
+    };
+  }
+
+  next.status = status ?? null;
+  return next;
+}
+
+export function createUserBookStore(props: BookActionsProps) {
+  let state: StoreState = {
+    view: props.userBook,
+    confirmed: props.userBook,
+    pending: 0,
+    error: null,
+    savedAt: null,
+  };
+  const listeners = new Set<() => void>();
+  const set = (patch: Partial<StoreState>) => {
+    state = { ...state, ...patch };
+    listeners.forEach((l) => l());
+  };
+  let queue: Promise<unknown> = Promise.resolve();
+
+  async function send(fields: UpdateFields, explicitSave: boolean) {
+    try {
+      const res = await fetch("/api/update-book", {
+        method: "POST",
+        headers: { "content-type": "application/json", accept: "application/json" },
+        body: JSON.stringify({ hiveId: props.hiveId, ...fields }),
+      });
+      const body = (await res.json().catch(() => ({}))) as {
+        success?: boolean;
+        message?: string;
+        userBook?: UserBookView;
+      };
+      if (!res.ok || !body.success || !body.userBook) {
+        throw new Error(body.message || `Could not save (${res.status})`);
+      }
+      const pending = state.pending - 1;
+      set({
+        confirmed: body.userBook,
+        pending,
+        view: pending === 0 ? body.userBook : state.view,
+        savedAt: explicitSave ? Date.now() : state.savedAt,
+      });
+    } catch (e) {
+      // The server's message names CIDs and lexicon paths; that belongs in
+      // the console, not next to the button.
+      console.error("[book] save failed:", e);
+      set({
+        pending: state.pending - 1,
+        view: state.confirmed,
+        error: "That change could not be saved. Your library was left as it was.",
+      });
+    }
+  }
+
+  return {
+    subscribe: (listener: () => void) => {
+      listeners.add(listener);
+      return () => listeners.delete(listener);
+    },
+    getSnapshot: () => state,
+    /** Apply at once, send in order. Resolves when this write has settled. */
+    update: (fields: UpdateFields, { explicitSave = false } = {}): Promise<void> => {
+      set({
+        view: applyOptimistic(state.view, fields, props),
+        pending: state.pending + 1,
+        error: null,
+      });
+      const run = () => send(fields, explicitSave);
+      queue = queue.then(run, run);
+      return queue as Promise<void>;
+    },
+    remove: async (): Promise<boolean> => {
+      set({ error: null });
+      try {
+        const res = await fetch(`/books/${props.hiveId}`, {
+          method: "DELETE",
+          headers: { accept: "application/json" },
+        });
+        const body = (await res.json().catch(() => ({}))) as { success?: boolean };
+        if (!res.ok || !body.success) throw new Error(`Could not remove (${res.status})`);
+        set({ view: null, confirmed: null });
+        return true;
+      } catch (e) {
+        console.error("[book] remove failed:", e);
+        set({ error: "The book could not be removed. Please try again." });
+        return false;
+      }
+    },
+    dismissError: () => {
+      set({ error: null });
+    },
+  };
+}

--- a/src/client/index.tsx
+++ b/src/client/index.tsx
@@ -63,24 +63,16 @@ document.addEventListener("DOMContentLoaded", () => {
     });
   }
 
-  const starRating = document.getElementById("star-rating");
-  if (starRating) {
-    void import("./components/StarRating").then(({ StarRating }) => {
-      render(
-        <StarRating
-          initialRating={Number(starRating.dataset["rating"]) || 0}
-          onChange={(rating) => {
-            const ratingInput = document.getElementById("rating-value") as HTMLInputElement;
-            ratingInput.value = rating.toString();
-
-            const ratingForm = document.getElementById("activity-form") as HTMLFormElement;
-
-            ratingForm.submit();
-          }}
-        />,
-        starRating,
-      );
-    });
+  // /books/:id — status, owned, rating, review, progress, dates. One store,
+  // three mounts; see components/book/index.tsx.
+  const bookActions = document.getElementById("mount-book-actions");
+  if (bookActions) {
+    const props = JSON.parse(bookActions.dataset["props"] || "null");
+    if (props) {
+      void import("./components/book/index").then(({ mountBookIslands }) => {
+        mountBookIslands(props);
+      });
+    }
   }
 
   const importTable = document.getElementById("import-table");

--- a/src/client/index.tsx
+++ b/src/client/index.tsx
@@ -67,11 +67,16 @@ document.addEventListener("DOMContentLoaded", () => {
   // three mounts; see components/book/index.tsx.
   const bookActions = document.getElementById("mount-book-actions");
   if (bookActions) {
-    const props = JSON.parse(bookActions.dataset["props"] || "null");
+    let props = null;
+    try {
+      props = JSON.parse(bookActions.dataset["props"] || "null");
+    } catch (err) {
+      console.error("[book] could not read island props:", err);
+    }
     if (props) {
-      void import("./components/book/index").then(({ mountBookIslands }) => {
-        mountBookIslands(props);
-      });
+      void import("./components/book/index")
+        .then(({ mountBookIslands }) => mountBookIslands(props))
+        .catch((err) => console.error("[book] island failed to load:", err));
     }
   }
 

--- a/src/db.ts
+++ b/src/db.ts
@@ -1066,6 +1066,18 @@ migrations["024"] = {
   },
 };
 
+migrations["025"] = {
+  async up(db: Kysely<unknown>) {
+    // Last PDS record seen for the row, so a write can merge locally instead
+    // of a getRecord round-trip per status click. Nullable: older rows fall
+    // back to the network read until the ingester refreshes them.
+    await db.schema.alterTable("user_book").addColumn("record", "text").execute();
+  },
+  async down(db: Kysely<unknown>) {
+    await db.schema.alterTable("user_book").dropColumn("record").execute();
+  },
+};
+
 // APIs
 
 export const createDb = (location: string): { db: Database; sqlite: DatabaseSync } => {

--- a/src/metrics.ts
+++ b/src/metrics.ts
@@ -260,6 +260,14 @@ export const ogRenderShedTotal = registry.register(
   new Counter("bookhive_og_render_shed_total", "OG renders rejected because the queue was full"),
 );
 
+/** Deferred book-record completions run after the wide event is written; this is their only signal. */
+export const userBookFollowUpTotal = registry.register(
+  new Counter(
+    "bookhive_user_book_follow_up_total",
+    "Deferred book-record completions (cover upload, catalog uri) by outcome",
+  ),
+);
+
 // ─── Cluster-wide gauges (primary worker only) ──────────────────────────────
 // Deliberately unlabelled by worker: these describe shared SQLite state, not
 // this process. Only the primary publishes them, so a scrape landing on
@@ -364,6 +372,12 @@ export const LABEL = {
   },
   /** For metrics that are per-process but carry no other dimension. */
   worker: labelKey(workerLabels()),
+  userBookFollowUp: {
+    completed: labelKey({ outcome: "completed" }),
+    nothing: labelKey({ outcome: "nothing" }),
+    conflict: labelKey({ outcome: "conflict" }),
+    failed: labelKey({ outcome: "failed" }),
+  },
   enrichQueue: {
     total: labelKey({ state: "total" }),
     claimed: labelKey({ state: "claimed" }),

--- a/src/pages/bookInfo.tsx
+++ b/src/pages/bookInfo.tsx
@@ -464,6 +464,34 @@ export const BookInfo: FC<{
                             </div>
                           </div>
                         </form>
+
+                        {/* Makes the fallback dropdown usable before the island
+                            loads. The island replaces this markup on hydration,
+                            leaving these listeners on detached nodes. */}
+                        <Script
+                          script={(document) => {
+                            const dropdown = document.getElementById("status-dropdown");
+                            const menu = document.getElementById("status-dropdown-menu");
+                            if (!dropdown || !menu) return;
+                            dropdown.addEventListener("click", () => {
+                              dropdown.setAttribute(
+                                "aria-expanded",
+                                dropdown.getAttribute("aria-expanded") === "true"
+                                  ? "false"
+                                  : "true",
+                              );
+                            });
+                            document.addEventListener("click", (e) => {
+                              if (
+                                dropdown.getAttribute("aria-expanded") === "true" &&
+                                !dropdown.contains(e.target as any) &&
+                                !menu.contains(e.target as any)
+                              ) {
+                                dropdown.setAttribute("aria-expanded", "false");
+                              }
+                            });
+                          }}
+                        />
                       </div>
 
                       {/* Owned toggle */}
@@ -1056,6 +1084,15 @@ export const BookInfo: FC<{
                     </form>
                   </div>
                 </dialog>
+                <Script
+                  script={(document) => {
+                    const btn = document.getElementById("delete-book-btn");
+                    const dialog = document.getElementById(
+                      "delete-book-dialog",
+                    ) as HTMLDialogElement | null;
+                    btn?.addEventListener("click", () => dialog?.showModal());
+                  }}
+                />
               </div>
             )}
           </div>

--- a/src/pages/bookInfo.tsx
+++ b/src/pages/bookInfo.tsx
@@ -258,9 +258,8 @@ export const BookInfo: FC<{
   if (meta?.publisher) pubDetails.push(meta.publisher);
   if (meta?.language) pubDetails.push(meta.language);
 
-  // Initial state for the client islands (src/client/components/book). The
-  // forms below are what the page looks like until they hydrate — and the
-  // only thing a no-JS visitor gets.
+  // Initial state for the islands (src/client/components/book). The forms
+  // below are the pre-hydration paint, and all a no-JS visitor gets.
   const actionProps: BookActionsProps | null = did
     ? {
         hiveId: book.id,
@@ -465,9 +464,8 @@ export const BookInfo: FC<{
                           </div>
                         </form>
 
-                        {/* Makes the fallback dropdown usable before the island
-                            loads. The island replaces this markup on hydration,
-                            leaving these listeners on detached nodes. */}
+                        {/* Makes the fallback dropdown work before the island
+                            loads; hydration detaches these nodes. */}
                         <Script
                           script={(document) => {
                             const dropdown = document.getElementById("status-dropdown");

--- a/src/pages/bookInfo.tsx
+++ b/src/pages/bookInfo.tsx
@@ -10,6 +10,8 @@ import type { HiveBook } from "../types";
 import { normalizeBookMeta } from "../utils/bookMeta";
 import { loadGenresForHiveBook } from "../utils/hiveBookGenres";
 import { hydrateUserBook } from "../utils/bookProgress";
+import { toUserBookView } from "../utils/userBookView";
+import type { BookActionsProps } from "../client/components/book/userBookStore";
 import { getUserLists } from "../utils/lists";
 import { getProfiles } from "../utils/getProfile";
 import { avatarImageUrl, coverImageUrl, sourceCoverImageUrl } from "../utils/imageProxy";
@@ -256,6 +258,19 @@ export const BookInfo: FC<{
   if (meta?.publisher) pubDetails.push(meta.publisher);
   if (meta?.language) pubDetails.push(meta.language);
 
+  // Initial state for the client islands (src/client/components/book). The
+  // forms below are what the page looks like until they hydrate — and the
+  // only thing a no-JS visitor gets.
+  const actionProps: BookActionsProps | null = did
+    ? {
+        hiveId: book.id,
+        title: book.title,
+        authors: book.authors,
+        numPages: meta?.numPages ? Number(meta.numPages) : null,
+        userBook: usersBook ? toUserBookView(usersBook) : null,
+      }
+    : null;
+
   return (
     <div class="mx-auto max-w-4xl space-y-8">
       {/* ===== SECTION 1: Book Hero ===== */}
@@ -334,188 +349,172 @@ export const BookInfo: FC<{
 
               {/* === Action Row === */}
               <div class="mb-5 space-y-3">
-                <div class="flex items-center gap-2">
-                  {/* Status dropdown */}
-                  {did && (
-                    <div class="relative">
-                      <form action="/books" method="post" id="status-form">
+                <div class="flex flex-wrap items-center gap-2">
+                  {actionProps && (
+                    <div
+                      id="mount-book-actions"
+                      class="contents"
+                      data-props={JSON.stringify(actionProps)}
+                    >
+                      {/* Status dropdown */}
+                      <div class="relative">
+                        <form action="/books" method="post" id="status-form">
+                          <input type="hidden" name="authors" value={book.authors} />
+                          <input type="hidden" name="title" value={book.title} />
+                          <input type="hidden" name="hiveId" value={book.id} />
+                          {book.cover && (
+                            <input type="hidden" name="coverImage" value={book.cover} />
+                          )}
+                          {usersBook?.stars && (
+                            <input type="hidden" name="stars" value={String(usersBook.stars)} />
+                          )}
+                          {usersBook?.review && (
+                            <input type="hidden" name="review" value={usersBook.review} />
+                          )}
+                          {usersBook?.owned ? <input type="hidden" name="owned" value="1" /> : null}
+                          {usersBook?.startedAt ? (
+                            <input type="hidden" name="startedAt" value={usersBook.startedAt} />
+                          ) : (
+                            <input type="hidden" name="startedAt" id="auto-started-at" value="" />
+                          )}
+                          {usersBook?.finishedAt ? (
+                            <input type="hidden" name="finishedAt" value={usersBook.finishedAt} />
+                          ) : (
+                            <input type="hidden" name="finishedAt" id="auto-finished-at" value="" />
+                          )}
+
+                          <button
+                            type="button"
+                            aria-haspopup="listbox"
+                            aria-expanded="false"
+                            id="status-dropdown"
+                            class={`peer cursor-pointer rounded-lg px-4 py-2 text-sm font-semibold shadow-sm transition-[background-color,scale] duration-150 active:scale-[0.96] focus:ring-2 focus:ring-primary focus:outline-none ${
+                              usersBook?.status
+                                ? "bg-primary text-primary-foreground hover:bg-primary/90"
+                                : "bg-accent text-accent-foreground hover:bg-accent/80"
+                            }`}
+                          >
+                            <span class="flex items-center gap-1.5 capitalize">
+                              <span>
+                                {(usersBook?.status &&
+                                  (usersBook.status in BOOK_STATUS_MAP
+                                    ? BOOK_STATUS_MAP[
+                                        usersBook.status as keyof typeof BOOK_STATUS_MAP
+                                      ]
+                                    : usersBook.status)) ||
+                                  "Want to Read"}
+                              </span>
+                              <svg
+                                class="h-4 w-4 opacity-70"
+                                viewBox="0 0 20 20"
+                                fill="currentColor"
+                                aria-hidden="true"
+                              >
+                                <path
+                                  fillRule="evenodd"
+                                  d="M5.23 7.21a.75.75 0 011.06.02L10 11.168l3.71-3.938a.75.75 0 111.08 1.04l-4.25 4.5a.75.75 0 01-1.08 0l-4.25-4.5a.75.75 0 01.02-1.06z"
+                                  clipRule="evenodd"
+                                />
+                              </svg>
+                            </span>
+                          </button>
+
+                          <div
+                            role="listbox"
+                            id="status-dropdown-menu"
+                            class="invisible absolute z-10 mt-1 w-48 rounded-lg bg-card opacity-0 shadow-lg ring-1 ring-border transition-[opacity,visibility] duration-100 ease-in-out peer-aria-expanded:visible peer-aria-expanded:opacity-100"
+                          >
+                            <div class="p-1">
+                              {[
+                                { value: BOOK_STATUS.FINISHED, label: "Read" },
+                                { value: BOOK_STATUS.READING, label: "Reading" },
+                                { value: BOOK_STATUS.WANTTOREAD, label: "Want to Read" },
+                                { value: BOOK_STATUS.ABANDONED, label: "Abandoned" },
+                              ].map((status) => (
+                                <button
+                                  key={status.value}
+                                  type="submit"
+                                  role="option"
+                                  aria-selected={usersBook?.status === status.value}
+                                  name="status"
+                                  value={status.value}
+                                  class={`relative my-0.5 w-full cursor-pointer rounded-[4px] px-3 py-2 text-left text-sm ${
+                                    usersBook?.status === status.value
+                                      ? "bg-primary text-primary-foreground"
+                                      : "text-foreground hover:bg-muted"
+                                  }`}
+                                >
+                                  <span class="block truncate">{status.label}</span>
+                                  {usersBook?.status === status.value && (
+                                    <span
+                                      class="absolute inset-y-0 right-2 flex items-center"
+                                      aria-hidden="true"
+                                    >
+                                      <svg class="h-4 w-4" viewBox="0 0 20 20" fill="currentColor">
+                                        <path
+                                          fillRule="evenodd"
+                                          d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z"
+                                          clipRule="evenodd"
+                                        />
+                                      </svg>
+                                    </span>
+                                  )}
+                                </button>
+                              ))}
+                            </div>
+                          </div>
+                        </form>
+                      </div>
+
+                      {/* Owned toggle */}
+                      <form action="/books" method="post">
                         <input type="hidden" name="authors" value={book.authors} />
                         <input type="hidden" name="title" value={book.title} />
                         <input type="hidden" name="hiveId" value={book.id} />
                         {book.cover && <input type="hidden" name="coverImage" value={book.cover} />}
+                        {usersBook?.status && (
+                          <input type="hidden" name="status" value={usersBook.status} />
+                        )}
                         {usersBook?.stars && (
                           <input type="hidden" name="stars" value={String(usersBook.stars)} />
                         )}
                         {usersBook?.review && (
                           <input type="hidden" name="review" value={usersBook.review} />
                         )}
-                        {usersBook?.owned ? <input type="hidden" name="owned" value="1" /> : null}
-                        {usersBook?.startedAt ? (
+                        {usersBook?.startedAt && (
                           <input type="hidden" name="startedAt" value={usersBook.startedAt} />
-                        ) : (
-                          <input type="hidden" name="startedAt" id="auto-started-at" value="" />
                         )}
-                        {usersBook?.finishedAt ? (
+                        {usersBook?.finishedAt && (
                           <input type="hidden" name="finishedAt" value={usersBook.finishedAt} />
-                        ) : (
-                          <input type="hidden" name="finishedAt" id="auto-finished-at" value="" />
                         )}
-
                         <button
-                          type="button"
-                          aria-haspopup="listbox"
-                          aria-expanded="false"
-                          id="status-dropdown"
-                          class={`peer cursor-pointer rounded-lg px-4 py-2 text-sm font-semibold shadow-sm transition-[background-color,scale] duration-150 active:scale-[0.96] focus:ring-2 focus:ring-primary focus:outline-none ${
-                            usersBook?.status
+                          type="submit"
+                          name="owned"
+                          value={usersBook?.owned ? "false" : "true"}
+                          class={`cursor-pointer rounded-lg px-3 py-2 text-sm font-semibold shadow-sm transition-[background-color,scale] duration-150 active:scale-[0.96] focus:ring-2 focus:ring-primary focus:outline-none ${
+                            usersBook?.owned
                               ? "bg-primary text-primary-foreground hover:bg-primary/90"
                               : "bg-accent text-accent-foreground hover:bg-accent/80"
                           }`}
                         >
-                          <span class="flex items-center gap-1.5 capitalize">
-                            <span>
-                              {(usersBook?.status &&
-                                (usersBook.status in BOOK_STATUS_MAP
-                                  ? BOOK_STATUS_MAP[
-                                      usersBook.status as keyof typeof BOOK_STATUS_MAP
-                                    ]
-                                  : usersBook.status)) ||
-                                "Want to Read"}
-                            </span>
+                          <span class="flex items-center gap-1.5">
                             <svg
-                              class="h-4 w-4 opacity-70"
-                              viewBox="0 0 20 20"
-                              fill="currentColor"
-                              aria-hidden="true"
+                              class="h-4 w-4"
+                              viewBox="0 0 24 24"
+                              fill="none"
+                              stroke="currentColor"
+                              stroke-width="2"
+                              stroke-linecap="round"
+                              stroke-linejoin="round"
                             >
-                              <path
-                                fillRule="evenodd"
-                                d="M5.23 7.21a.75.75 0 011.06.02L10 11.168l3.71-3.938a.75.75 0 111.08 1.04l-4.25 4.5a.75.75 0 01-1.08 0l-4.25-4.5a.75.75 0 01.02-1.06z"
-                                clipRule="evenodd"
-                              />
+                              <path d="M4 19.5A2.5 2.5 0 016.5 17H20" />
+                              <path d="M6.5 2H20v20H6.5A2.5 2.5 0 014 19.5v-15A2.5 2.5 0 016.5 2z" />
                             </svg>
+                            {usersBook?.owned ? "Owned" : "Own"}
                           </span>
                         </button>
-
-                        <div
-                          role="listbox"
-                          id="status-dropdown-menu"
-                          class="invisible absolute z-10 mt-1 w-48 rounded-lg bg-card opacity-0 shadow-lg ring-1 ring-border transition-[opacity,visibility] duration-100 ease-in-out peer-aria-expanded:visible peer-aria-expanded:opacity-100"
-                        >
-                          <div class="p-1">
-                            {[
-                              { value: BOOK_STATUS.FINISHED, label: "Read" },
-                              { value: BOOK_STATUS.READING, label: "Reading" },
-                              { value: BOOK_STATUS.WANTTOREAD, label: "Want to Read" },
-                              { value: BOOK_STATUS.ABANDONED, label: "Abandoned" },
-                            ].map((status) => (
-                              <button
-                                key={status.value}
-                                type="submit"
-                                role="option"
-                                aria-selected={usersBook?.status === status.value}
-                                name="status"
-                                value={status.value}
-                                class={`relative my-0.5 w-full cursor-pointer rounded-[4px] px-3 py-2 text-left text-sm ${
-                                  usersBook?.status === status.value
-                                    ? "bg-primary text-primary-foreground"
-                                    : "text-foreground hover:bg-muted"
-                                }`}
-                              >
-                                <span class="block truncate">{status.label}</span>
-                                {usersBook?.status === status.value && (
-                                  <span
-                                    class="absolute inset-y-0 right-2 flex items-center"
-                                    aria-hidden="true"
-                                  >
-                                    <svg class="h-4 w-4" viewBox="0 0 20 20" fill="currentColor">
-                                      <path
-                                        fillRule="evenodd"
-                                        d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z"
-                                        clipRule="evenodd"
-                                      />
-                                    </svg>
-                                  </span>
-                                )}
-                              </button>
-                            ))}
-                          </div>
-                        </div>
                       </form>
-
-                      <Script
-                        script={(document) => {
-                          const dropdown = document.getElementById("status-dropdown")!;
-                          const dropdownMenu = document.getElementById("status-dropdown-menu")!;
-                          dropdown.addEventListener("click", () => {
-                            dropdown.setAttribute(
-                              "aria-expanded",
-                              dropdown.getAttribute("aria-expanded") === "true" ? "false" : "true",
-                            );
-                          });
-                          document.addEventListener("click", (e) => {
-                            if (
-                              dropdown.getAttribute("aria-expanded") === "true" &&
-                              !dropdown.contains(e.target as any) &&
-                              !dropdownMenu.contains(e.target as any)
-                            ) {
-                              dropdown.setAttribute("aria-expanded", "false");
-                            }
-                          });
-                        }}
-                      />
                     </div>
-                  )}
-
-                  {/* Owned toggle */}
-                  {did && (
-                    <form action="/books" method="post">
-                      <input type="hidden" name="authors" value={book.authors} />
-                      <input type="hidden" name="title" value={book.title} />
-                      <input type="hidden" name="hiveId" value={book.id} />
-                      {book.cover && <input type="hidden" name="coverImage" value={book.cover} />}
-                      {usersBook?.status && (
-                        <input type="hidden" name="status" value={usersBook.status} />
-                      )}
-                      {usersBook?.stars && (
-                        <input type="hidden" name="stars" value={String(usersBook.stars)} />
-                      )}
-                      {usersBook?.review && (
-                        <input type="hidden" name="review" value={usersBook.review} />
-                      )}
-                      {usersBook?.startedAt && (
-                        <input type="hidden" name="startedAt" value={usersBook.startedAt} />
-                      )}
-                      {usersBook?.finishedAt && (
-                        <input type="hidden" name="finishedAt" value={usersBook.finishedAt} />
-                      )}
-                      <button
-                        type="submit"
-                        name="owned"
-                        value={usersBook?.owned ? "false" : "true"}
-                        class={`cursor-pointer rounded-lg px-3 py-2 text-sm font-semibold shadow-sm transition-[background-color,scale] duration-150 active:scale-[0.96] focus:ring-2 focus:ring-primary focus:outline-none ${
-                          usersBook?.owned
-                            ? "bg-primary text-primary-foreground hover:bg-primary/90"
-                            : "bg-accent text-accent-foreground hover:bg-accent/80"
-                        }`}
-                      >
-                        <span class="flex items-center gap-1.5">
-                          <svg
-                            class="h-4 w-4"
-                            viewBox="0 0 24 24"
-                            fill="none"
-                            stroke="currentColor"
-                            stroke-width="2"
-                            stroke-linecap="round"
-                            stroke-linejoin="round"
-                          >
-                            <path d="M4 19.5A2.5 2.5 0 016.5 17H20" />
-                            <path d="M6.5 2H20v20H6.5A2.5 2.5 0 014 19.5v-15A2.5 2.5 0 016.5 2z" />
-                          </svg>
-                          {usersBook?.owned ? "Owned" : "Own"}
-                        </span>
-                      </button>
-                    </form>
                   )}
 
                   {/* Logged-out CTA. Without this the action row holds nothing but the
@@ -661,13 +660,17 @@ export const BookInfo: FC<{
               </div>
 
               {/* Timestamp for logged-in users */}
-              {usersBook && (
-                <p class="mb-4 text-sm text-muted-foreground">
-                  {`${usersBook.finishedAt ? "Finished" : usersBook.startedAt ? "Started" : "Added"}: ${formatDistanceToNow(
-                    usersBook.finishedAt ?? usersBook.startedAt ?? usersBook.createdAt,
-                    { addSuffix: true },
-                  )}`}
-                </p>
+              {did && (
+                <div id="mount-book-timestamp">
+                  {usersBook && (
+                    <p class="mb-4 text-sm text-muted-foreground">
+                      {`${usersBook.finishedAt ? "Finished" : usersBook.startedAt ? "Started" : "Added"}: ${formatDistanceToNow(
+                        usersBook.finishedAt ?? usersBook.startedAt ?? usersBook.createdAt,
+                        { addSuffix: true },
+                      )}`}
+                    </p>
+                  )}
+                </div>
               )}
 
               {/* Metadata row */}
@@ -775,7 +778,7 @@ export const BookInfo: FC<{
 
       {/* ===== SECTION 3: Your Activity (auth'd, unified form) ===== */}
       {did && (
-        <div class="card">
+        <div class="card" id="mount-book-activity">
           <div class="card-body space-y-6">
             <h2 class="card-title">Your Activity</h2>
 
@@ -1053,69 +1056,10 @@ export const BookInfo: FC<{
                     </form>
                   </div>
                 </dialog>
-                <Script
-                  script={(document) => {
-                    const btn = document.getElementById("delete-book-btn");
-                    const dialog = document.getElementById(
-                      "delete-book-dialog",
-                    ) as HTMLDialogElement;
-                    btn?.addEventListener("click", () => dialog?.showModal());
-                  }}
-                />
               </div>
             )}
           </div>
         </div>
-      )}
-
-      {/* Progress auto-calc script */}
-      {did && (
-        <Script
-          script={(document) => {
-            const pageCurrent = document.getElementById(
-              "progress-pages-current",
-            ) as HTMLInputElement;
-            const pageTotal = document.getElementById("progress-pages-total") as HTMLInputElement;
-            const chapterCurrent = document.getElementById(
-              "progress-chapters-current",
-            ) as HTMLInputElement;
-            const chapterTotal = document.getElementById(
-              "progress-chapters-total",
-            ) as HTMLInputElement;
-            const percentInput = document.getElementById("progress-percent") as HTMLInputElement;
-            function parseNumber(value: string | null) {
-              const parsed = Number(value);
-              return Number.isFinite(parsed) ? parsed : null;
-            }
-            function updatePercent() {
-              if (!percentInput) return;
-              const currentPage = parseNumber(pageCurrent?.value);
-              const totalPages = parseNumber(pageTotal?.value);
-              const currentChapter = parseNumber(chapterCurrent?.value);
-              const totalChapters = parseNumber(chapterTotal?.value);
-              let percent = null;
-              if (currentPage !== null && totalPages && totalPages > 0) {
-                percent = Math.min(100, Math.max(0, Math.round((currentPage / totalPages) * 100)));
-              } else if (currentChapter !== null && totalChapters && totalChapters > 0) {
-                percent = Math.min(
-                  100,
-                  Math.max(0, Math.round((currentChapter / totalChapters) * 100)),
-                );
-              }
-              if (percent !== null) {
-                percentInput.value = percent.toString();
-              }
-              // Update progress bar
-              const bar = document.querySelector("[data-progress-bar]") as HTMLElement;
-              if (bar && percent !== null) {
-                bar.style.width = `${percent}%`;
-              }
-            }
-            [pageCurrent, pageTotal, chapterCurrent, chapterTotal].forEach((input) => {
-              input?.addEventListener("input", updatePercent);
-            });
-          }}
-        />
       )}
 
       {/* ===== SECTION 4: About the Author ===== */}

--- a/src/routes/admin.ts
+++ b/src/routes/admin.ts
@@ -292,6 +292,7 @@ const admin = new Hono<AppEnv>()
             stars: book.stars ?? null,
             bookProgress: book.bookProgress ?? null,
             previousReads: book.previousReads ?? null,
+            record: book,
           } satisfies UserBook);
         });
 
@@ -316,6 +317,7 @@ const admin = new Hono<AppEnv>()
                 stars: c.ref("excluded.stars"),
                 bookProgress: c.ref("excluded.bookProgress"),
                 previousReads: c.ref("excluded.previousReads"),
+                record: c.ref("excluded.record"),
               })),
             )
             .execute();

--- a/src/routes/api.tsx
+++ b/src/routes/api.tsx
@@ -127,14 +127,17 @@ const app = new Hono<AppEnv>()
         normalizedProgress.totalPages &&
         normalizedProgress.currentPage > normalizedProgress.totalPages
       ) {
-        throw new Error("Current page cannot exceed total pages");
+        return c.json({ success: false, message: "Current page cannot exceed total pages" }, 400);
       }
       if (
         normalizedProgress.currentChapter &&
         normalizedProgress.totalChapters &&
         normalizedProgress.currentChapter > normalizedProgress.totalChapters
       ) {
-        throw new Error("Current chapter cannot exceed total chapters");
+        return c.json(
+          { success: false, message: "Current chapter cannot exceed total chapters" },
+          400,
+        );
       }
     }
     if (normalizedProgress !== undefined) {

--- a/src/routes/api.tsx
+++ b/src/routes/api.tsx
@@ -12,7 +12,8 @@ import type { AppEnv } from "../context";
 import { ids, validateMain } from "../bsky/lexicon";
 import { BOOK_STATUS } from "../constants";
 import type { BookProgress, HiveId } from "../types";
-import { updateBookRecord } from "../utils/getBook";
+import { getUserBook, updateBookRecord } from "../utils/getBook";
+import { toUserBookView } from "../utils/userBookView";
 
 /**
  * Convert a date-input value to a full ISO datetime. YYYY-MM-DD inputs are
@@ -84,7 +85,26 @@ const updateBookSchema = z.object({
     .optional(),
 });
 
+const userBookQuerySchema = z.object({
+  hiveId: z.string().regex(/^bk_[A-Za-z0-9]+$/),
+});
+
 const app = new Hono<AppEnv>()
+  // Read half of the update-book contract. Cookie DID only — no OAuth
+  // restore, since nothing here touches the PDS.
+  .get("/user-book", zValidator("query", userBookQuerySchema), async (c) => {
+    const did = await c.get("ctx").getSessionDid();
+    if (!did) {
+      return c.json({ success: false, message: "Invalid Session" }, 401);
+    }
+    const { hiveId } = c.req.valid("query");
+    const userBook = await getUserBook({
+      ctx: c.get("ctx"),
+      agent: { did },
+      hiveId: hiveId as HiveId,
+    });
+    return c.json({ success: true, userBook: userBook ? toUserBookView(userBook) : null });
+  })
   .post("/update-book", zValidator("json", updateBookSchema), async (c) => {
     const agent = await c.get("ctx").getSessionAgent();
     if (!agent) {
@@ -130,7 +150,7 @@ const app = new Hono<AppEnv>()
     try {
       await c.get("ctx").kv.setItem(bookLockKey, hiveId);
       startTime(c, "pds_update_book");
-      await updateBookRecord({
+      const { userBook } = await updateBookRecord({
         ctx: c.get("ctx"),
         agent,
         hiveId: hiveId as HiveId,
@@ -142,7 +162,7 @@ const app = new Hono<AppEnv>()
         hiveId,
         userDid: agent.did,
       });
-      return c.json({ success: true, message: "Book updated" });
+      return c.json({ success: true, message: "Book updated", userBook: toUserBookView(userBook) });
     } catch (e) {
       c.get("ctx").addWideEventContext({
         api_update_book: "failed",

--- a/src/routes/books.tsx
+++ b/src/routes/books.tsx
@@ -14,6 +14,7 @@ import { CommentsSection } from "../pages/comments";
 import { Error as ErrorPage } from "../pages/error";
 import type { HiveId } from "../types";
 import { updateBookRecord } from "../utils/getBook";
+import { toUserBookView } from "../utils/userBookView";
 import { enrichBookWithDetailedData } from "../utils/enrichBookData";
 import { enqueueEnrichment } from "../utils/enrichQueue";
 import { withTimeout } from "../utils/semaphore";
@@ -341,7 +342,7 @@ const app = new Hono<AppEnv>()
         try {
           await c.get("ctx").kv.setItem(bookLockKey, hiveId);
           startTime(c, "pds_update_book");
-          await updateBookRecord({
+          const { userBook } = await updateBookRecord({
             ctx: c.get("ctx"),
             agent,
             hiveId: hiveId as HiveId,
@@ -360,6 +361,11 @@ const app = new Hono<AppEnv>()
             } as Partial<BookRecord.Record> & { coverImage?: string },
           });
           endTime(c, "pds_update_book");
+          // Same form, two clients: a fetch() caller gets the view back and
+          // stays on the page; a plain <form> still gets the redirect.
+          if (c.req.header("accept")?.includes("application/json")) {
+            return c.json({ success: true, userBook: toUserBookView(userBook) });
+          }
         } catch (e) {
           c.set("requestError", e);
           c.get("ctx").addWideEventContext({ write_book: "failed" });

--- a/src/routes/lib.ts
+++ b/src/routes/lib.ts
@@ -459,6 +459,7 @@ export async function refetchBooks({
       stars: book.stars,
       bookProgress: book.bookProgress ?? null,
       previousReads: book.previousReads ?? null,
+      record: book,
     });
   });
 
@@ -483,6 +484,7 @@ export async function refetchBooks({
           stars: c.ref("excluded.stars"),
           bookProgress: c.ref("excluded.bookProgress"),
           previousReads: c.ref("excluded.previousReads"),
+          record: c.ref("excluded.record"),
         })),
       )
       .execute();

--- a/src/routes/lib.ts
+++ b/src/routes/lib.ts
@@ -542,13 +542,12 @@ export async function refetchBooks({
             `applyWrites hiveBookUri backfill failed: data=${JSON.stringify(response.data)}`,
           );
         }
-        // Mirror what we just wrote onto the rows. Skipping this leaves every
-        // backfilled row holding a superseded cid, so the user's next edit
-        // spends a CAS failure and a re-read before it can land.
+        // Mirror what we wrote onto the rows: a superseded cid costs the
+        // user's next edit a CAS failure and a re-read.
         const results =
           (response.data as { results?: Array<{ uri?: string; cid?: string }> }).results ?? [];
-        // One transaction: bun:sqlite is synchronous, and a 5k-book library
-        // issuing these as separate autocommits costs ~1.8s of worker CPU.
+        // One transaction: as autocommits this measured ~1.8s of worker CPU
+        // for a 5k-book library.
         await ctx.db.transaction().execute(async (trx) => {
           for (const [index, write] of batch.entries()) {
             const result = results[index];

--- a/src/routes/lib.ts
+++ b/src/routes/lib.ts
@@ -547,16 +547,20 @@ export async function refetchBooks({
         // spends a CAS failure and a re-read before it can land.
         const results =
           (response.data as { results?: Array<{ uri?: string; cid?: string }> }).results ?? [];
-        for (const [index, write] of batch.entries()) {
-          const result = results[index];
-          if (!result?.uri || !result.cid) continue;
-          await ctx.db
-            .updateTable("user_book")
-            .set({ cid: result.cid, record: JSON.stringify(write.value) })
-            .where("uri", "=", result.uri)
-            .where("userDid", "=", agent.did)
-            .execute();
-        }
+        // One transaction: bun:sqlite is synchronous, and a 5k-book library
+        // issuing these as separate autocommits costs ~1.8s of worker CPU.
+        await ctx.db.transaction().execute(async (trx) => {
+          for (const [index, write] of batch.entries()) {
+            const result = results[index];
+            if (!result?.uri || !result.cid) continue;
+            await trx
+              .updateTable("user_book")
+              .set({ cid: result.cid, record: JSON.stringify(write.value) })
+              .where("uri", "=", result.uri)
+              .where("userDid", "=", agent.did)
+              .execute();
+          }
+        });
       }
     }
   }

--- a/src/routes/lib.ts
+++ b/src/routes/lib.ts
@@ -533,13 +533,29 @@ export async function refetchBooks({
         }));
 
       for (let i = 0; i < writes.length; i += 200) {
+        const batch = writes.slice(i, i + 200);
         const response = await agent.post("com.atproto.repo.applyWrites", {
-          input: { repo: agent.did, writes: writes.slice(i, i + 200) },
+          input: { repo: agent.did, writes: batch },
         });
         if (!response.ok) {
           throw new Error(
             `applyWrites hiveBookUri backfill failed: data=${JSON.stringify(response.data)}`,
           );
+        }
+        // Mirror what we just wrote onto the rows. Skipping this leaves every
+        // backfilled row holding a superseded cid, so the user's next edit
+        // spends a CAS failure and a re-read before it can land.
+        const results =
+          (response.data as { results?: Array<{ uri?: string; cid?: string }> }).results ?? [];
+        for (const [index, write] of batch.entries()) {
+          const result = results[index];
+          if (!result?.uri || !result.cid) continue;
+          await ctx.db
+            .updateTable("user_book")
+            .set({ cid: result.cid, record: JSON.stringify(write.value) })
+            .where("uri", "=", result.uri)
+            .where("userDid", "=", agent.did)
+            .execute();
         }
       }
     }

--- a/src/types.ts
+++ b/src/types.ts
@@ -5,6 +5,10 @@ export type BlobRef = { ref: { $link: string }; mimeType: string };
 
 export type ProfileViewDetailed = AppBskyActorDefs.ProfileViewDetailed;
 
+import type { Main as BookRecordValue } from "./bsky/lexicon/generated/types/buzz/bookhive/book";
+
+/** The `buzz.bookhive.book` record as it lives on a PDS. */
+export type { BookRecordValue };
 export type * as GetBook from "./bsky/lexicon/generated/types/buzz/bookhive/getBook";
 export type * as GetBookIdentifiers from "./bsky/lexicon/generated/types/buzz/bookhive/getBookIdentifiers";
 export type * as GetProfile from "./bsky/lexicon/generated/types/buzz/bookhive/getProfile";
@@ -104,11 +108,18 @@ export type UserBook = {
    * History of prior reads (re-reads), most recent first. JSON in DB.
    */
   previousReads: PreviousRead[] | null;
+  /**
+   * Last PDS record seen for this row (mig 025): carries `cover`, `identifiers`
+   * and `hiveBookUri`, which the columns don't, so a write can merge locally
+   * instead of reading the PDS first. Null on rows older than the column.
+   */
+  record: BookRecordValue | null;
 };
 
-export type UserBookRow = Omit<UserBook, "bookProgress" | "previousReads"> & {
+export type UserBookRow = Omit<UserBook, "bookProgress" | "previousReads" | "record"> & {
   bookProgress: string | null;
   previousReads: string | null;
+  record: string | null;
 };
 
 export type Buzz = {

--- a/src/utils/bookProgress.ts
+++ b/src/utils/bookProgress.ts
@@ -1,4 +1,4 @@
-import type { BookProgress, PreviousRead } from "../types";
+import type { BookProgress, BookRecordValue, PreviousRead } from "../types";
 
 function parseArray(json: string | null): PreviousRead[] | null {
   if (!json) return null;
@@ -10,28 +10,45 @@ function parseArray(json: string | null): PreviousRead[] | null {
   }
 }
 
+function parseRecord(json: string | null | undefined): BookRecordValue | null {
+  if (!json) return null;
+  try {
+    const parsed = JSON.parse(json);
+    return parsed && typeof parsed === "object" ? (parsed as BookRecordValue) : null;
+  } catch {
+    return null;
+  }
+}
+
 export function hydrateUserBook<
-  T extends { bookProgress: string | null; previousReads: string | null },
+  T extends { bookProgress: string | null; previousReads: string | null; record?: string | null },
 >(
   row: T,
-): Omit<T, "bookProgress" | "previousReads"> & {
+): Omit<T, "bookProgress" | "previousReads" | "record"> & {
   bookProgress: BookProgress | null;
   previousReads: PreviousRead[] | null;
+  record: BookRecordValue | null;
 } {
   return {
     ...row,
     bookProgress: row.bookProgress ? JSON.parse(row.bookProgress) : null,
     previousReads: parseArray(row.previousReads),
+    record: parseRecord(row.record),
   };
 }
 
 export function serializeUserBook<
-  T extends { bookProgress: BookProgress | null; previousReads: PreviousRead[] | null },
+  T extends {
+    bookProgress: BookProgress | null;
+    previousReads: PreviousRead[] | null;
+    record: BookRecordValue | null;
+  },
 >(
   book: T,
-): Omit<T, "bookProgress" | "previousReads"> & {
+): Omit<T, "bookProgress" | "previousReads" | "record"> & {
   bookProgress: string | null;
   previousReads: string | null;
+  record: string | null;
 } {
   return {
     ...book,
@@ -40,5 +57,7 @@ export function serializeUserBook<
       book.previousReads && book.previousReads.length > 0
         ? JSON.stringify(book.previousReads)
         : null,
+    // CAR-sourced CID objects stringify to `{ $link }` via toJSON, so this is always wire-shaped.
+    record: book.record ? JSON.stringify(book.record) : null,
   };
 }

--- a/src/utils/bookRecordWrite.ts
+++ b/src/utils/bookRecordWrite.ts
@@ -1,12 +1,39 @@
 /**
- * CAS write of a book record. The merge is computed from local state, so the
- * write must fail if the PDS holds something we have not seen. `applyWrites`
- * only offers `swapCommit` (whole repo, fails on any unrelated write), hence
- * `putRecord`.
+ * CAS read/write of a book record. The merge is computed from local state, so
+ * the write must fail if the PDS holds something we have not seen.
+ * `applyWrites` only offers `swapCommit` (whole repo, fails on any unrelated
+ * write), hence `putRecord`.
  */
 import type { SessionClient } from "../auth/client";
-import { ids } from "../bsky/lexicon";
+import { ids, Book as BookRecord } from "../bsky/lexicon";
 import type { BookRecordValue } from "../types";
+
+/** Current record on the PDS. Not pinned to a cid: a stale pin 404s and looked like "no record". */
+export async function getBookRecord({
+  agent,
+  uri,
+}: {
+  agent: Pick<SessionClient, "did" | "get">;
+  uri: string;
+}): Promise<{ value: BookRecordValue; cid: string } | null> {
+  const res = await agent.get("com.atproto.repo.getRecord", {
+    params: {
+      repo: agent.did,
+      collection: ids.BuzzBookhiveBook,
+      rkey: uri.split("/").at(-1)!,
+    },
+  });
+  const payload = res.ok ? (res.data as { value?: unknown; cid?: string }) : null;
+  // A cid is required: there is nothing to compare-and-swap on without one.
+  if (!payload?.value || !payload.cid) return null;
+  // A record failing our validator is still the user's record; merging onto it
+  // is how the offending field gets overwritten. Refusing bricks the book.
+  const parsed = BookRecord.validateRecord(payload.value);
+  return {
+    value: (parsed.success ? parsed.value : payload.value) as BookRecordValue,
+    cid: payload.cid,
+  };
+}
 
 export type BookRecordWriteResult =
   | { ok: true; uri: string; cid: string }

--- a/src/utils/bookRecordWrite.ts
+++ b/src/utils/bookRecordWrite.ts
@@ -1,0 +1,58 @@
+/**
+ * CAS write of a book record. The merge is computed from local state, so the
+ * write must fail if the PDS holds something we have not seen. `applyWrites`
+ * only offers `swapCommit` (whole repo, fails on any unrelated write), hence
+ * `putRecord`.
+ */
+import type { SessionClient } from "../auth/client";
+import { ids } from "../bsky/lexicon";
+import type { BookRecordValue } from "../types";
+
+export type BookRecordWriteResult =
+  | { ok: true; uri: string; cid: string }
+  | { ok: false; error: string; message?: string };
+
+/** The PDS's error name when `swapRecord` does not match the current CID. */
+export const INVALID_SWAP = "InvalidSwap";
+
+export async function writeBookRecord({
+  agent,
+  rkey,
+  record,
+  swapRecord,
+}: {
+  agent: Pick<SessionClient, "did" | "post">;
+  rkey: string;
+  record: BookRecordValue;
+  /** CID the record must still have; `null` creates. There is deliberately no "don't check". */
+  swapRecord: string | null;
+}): Promise<BookRecordWriteResult> {
+  const response =
+    swapRecord === null
+      ? await agent.post("com.atproto.repo.createRecord", {
+          input: {
+            repo: agent.did,
+            collection: ids.BuzzBookhiveBook,
+            rkey,
+            record,
+          },
+        })
+      : await agent.post("com.atproto.repo.putRecord", {
+          input: {
+            repo: agent.did,
+            collection: ids.BuzzBookhiveBook,
+            rkey,
+            record,
+            swapRecord,
+          },
+        });
+
+  if (!response.ok) {
+    return { ok: false, error: response.data.error, message: response.data.message };
+  }
+  const data = response.data as { uri?: string; cid?: string };
+  if (!data.uri || !data.cid) {
+    return { ok: false, error: "MalformedResponse", message: "PDS returned no uri/cid" };
+  }
+  return { ok: true, uri: data.uri, cid: data.cid };
+}

--- a/src/utils/ensureBookCataloged.ts
+++ b/src/utils/ensureBookCataloged.ts
@@ -11,6 +11,20 @@ import { withTimeout } from "./semaphore";
 const ENRICH_TIMEOUT_MS = 10_000;
 const CATALOG_TIMEOUT_MS = 10_000;
 
+/** Fast path only — a status click must never wait on a scrape. The follow-up runs the rest. */
+export async function getCatalogedBookUri(
+  ctx: Pick<BookUtilContext, "db" | "serviceAccountAgent">,
+  hiveId: HiveId,
+): Promise<string | undefined> {
+  if (!ctx.serviceAccountAgent) return undefined;
+  const row = await ctx.db
+    .selectFrom("hive_book")
+    .select("hiveBookAtUri")
+    .where("id", "=", hiveId)
+    .executeTakeFirst();
+  return row?.hiveBookAtUri ?? undefined;
+}
+
 /**
  * Safety net called immediately before writing a book to a user's PDS.
  *

--- a/src/utils/getBook.test.ts
+++ b/src/utils/getBook.test.ts
@@ -7,10 +7,11 @@ import memoryDriver from "unstorage/drivers/memory";
 import type { SessionClient } from "../auth/client";
 import { wrapBunSqliteForKysely } from "../bun-sqlite-kysely";
 import type { BookUtilContext } from "../context";
-import { FINISHED, READING, WANTTOREAD } from "../constants";
+import { ABANDONED, FINISHED, READING, WANTTOREAD } from "../constants";
 import { migrateToLatest, type Database, type DatabaseSchema } from "../db";
 import type { BookRecordValue, HiveId } from "../types";
 import { getBookRecord, getUserBook, updateBookRecord } from "./getBook";
+import { completeUserBookRecord } from "./userBookFollowUp";
 import { recordFromUserBook } from "./userBookStore";
 import { toUserBookView } from "./userBookView";
 
@@ -101,6 +102,21 @@ const baseRecord = (over: Partial<BookRecordValue> = {}): BookRecordValue => ({
   hiveBookUri: "at://did:plc:bookhive/buzz.bookhive.hiveBook/dune",
   ...over,
 });
+
+/** One-pixel PNG on a loopback port, so the cover path runs for real. */
+function coverServer() {
+  return Bun.serve({
+    port: 0,
+    fetch: () =>
+      new Response(
+        Buffer.from(
+          "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNkYPhfDwAChwGA60e6kgAAAABJRU5ErkJggg==",
+          "base64",
+        ),
+        { headers: { "content-type": "image/png" } },
+      ),
+  });
+}
 
 describe("updateBookRecord", () => {
   let db: Database;
@@ -292,6 +308,72 @@ describe("updateBookRecord", () => {
     }
   });
 
+  it("does not revert a column written while the follow-up is in flight", async () => {
+    const server = coverServer();
+    try {
+      const { agent } = fakePds();
+      // Create with no cover, so nothing is deferred yet and we hold the same
+      // stale snapshot a real follow-up would have captured.
+      const { userBook, followUp } = await updateBookRecord({
+        ctx,
+        agent,
+        hiveId: HIVE_ID,
+        updates: { status: WANTTOREAD, owned: false },
+      });
+      // The create's own follow-up is keyed by uri; let it settle so the one
+      // under test isn't deduped onto it.
+      await followUp;
+      expect(userBook.owned).toBe(0);
+
+      // A library upload marks the book owned, and KOSync pushes progress.
+      // Neither column lives in the PDS record, so the CAS cannot protect them.
+      await db
+        .updateTable("user_book")
+        .set({ owned: 1, bookProgress: JSON.stringify({ percent: 25, updatedAt: "x" }) })
+        .where("uri", "=", URI)
+        .execute();
+
+      const outcome = await completeUserBookRecord({
+        ctx,
+        agent,
+        userBook,
+        coverImage: `${server.url}cover.png`,
+      });
+      expect(outcome).toBe("completed");
+
+      const row = await getUserBook({ ctx, agent, hiveId: HIVE_ID });
+      expect(row?.owned).toBe(1);
+      expect(row?.bookProgress?.percent).toBe(25);
+      expect(row?.record?.cover).toBeTruthy();
+      expect(row?.cid).toBe("cid2");
+    } finally {
+      await server.stop(true);
+    }
+  });
+
+  it("leaves the row alone when it has moved on since the follow-up was scheduled", async () => {
+    const server = coverServer();
+    try {
+      const { agent } = fakePds();
+      const { userBook, followUp } = await updateBookRecord({
+        ctx,
+        agent,
+        hiveId: HIVE_ID,
+        updates: { status: WANTTOREAD },
+      });
+      await followUp;
+      // Another write lands first; the follow-up's snapshot cid is now stale.
+      await db.updateTable("user_book").set({ cid: "cid-newer" }).where("uri", "=", URI).execute();
+
+      await completeUserBookRecord({ ctx, agent, userBook, coverImage: `${server.url}cover.png` });
+
+      const row = await getUserBook({ ctx, agent, hiveId: HIVE_ID });
+      expect(row?.cid).toBe("cid-newer");
+    } finally {
+      await server.stop(true);
+    }
+  });
+
   it("skips the follow-up when the record is already complete", async () => {
     const original = baseRecord();
     const { agent, names } = fakePds({ value: original, cid: "cid0" });
@@ -339,6 +421,54 @@ describe("updateBookRecord", () => {
     } finally {
       await server.stop(true);
     }
+  });
+
+  it("keeps the recorded start date when a partial update re-asserts Reading", async () => {
+    // The island sends only what changed, so `startedAt` is absent here. It
+    // must not be re-stamped to today over a date the user already has.
+    const original = baseRecord({ status: ABANDONED, startedAt: "2026-03-01T09:00:00.000Z" });
+    const { agent } = fakePds({ value: original, cid: "cid0" });
+    await seedRow(original, "cid0", { status: ABANDONED, startedAt: "2026-03-01T09:00:00.000Z" });
+
+    const { book } = await updateBookRecord({
+      ctx,
+      agent,
+      hiveId: HIVE_ID,
+      updates: { status: READING },
+    });
+
+    expect(book.status).toBe(READING);
+    expect(book.startedAt).toBe("2026-03-01T09:00:00.000Z");
+  });
+
+  it("keeps the recorded finish date when a partial update re-asserts Read", async () => {
+    const original = baseRecord({ status: ABANDONED, finishedAt: "2026-04-02T09:00:00.000Z" });
+    const { agent } = fakePds({ value: original, cid: "cid0" });
+    await seedRow(original, "cid0", { status: ABANDONED, finishedAt: "2026-04-02T09:00:00.000Z" });
+
+    const { book } = await updateBookRecord({
+      ctx,
+      agent,
+      hiveId: HIVE_ID,
+      updates: { status: FINISHED },
+    });
+
+    expect(book.finishedAt).toBe("2026-04-02T09:00:00.000Z");
+  });
+
+  it("still stamps a start date when the book has none", async () => {
+    const original = baseRecord({ status: WANTTOREAD });
+    const { agent } = fakePds({ value: original, cid: "cid0" });
+    await seedRow(original, "cid0");
+
+    const { book } = await updateBookRecord({
+      ctx,
+      agent,
+      hiveId: HIVE_ID,
+      updates: { status: READING },
+    });
+
+    expect(book.startedAt).toBeTruthy();
   });
 
   it("refuses to create over an existing rkey when the record cannot be read", async () => {

--- a/src/utils/getBook.test.ts
+++ b/src/utils/getBook.test.ts
@@ -7,7 +7,7 @@ import memoryDriver from "unstorage/drivers/memory";
 import type { SessionClient } from "../auth/client";
 import { wrapBunSqliteForKysely } from "../bun-sqlite-kysely";
 import type { BookUtilContext } from "../context";
-import { ABANDONED, FINISHED, READING, WANTTOREAD } from "../constants";
+import { FINISHED, READING, WANTTOREAD } from "../constants";
 import { migrateToLatest, type Database, type DatabaseSchema } from "../db";
 import type { BookRecordValue, HiveId } from "../types";
 import { getBookRecord, getUserBook, updateBookRecord } from "./getBook";
@@ -423,28 +423,50 @@ describe("updateBookRecord", () => {
     }
   });
 
-  it("keeps the recorded start date when a partial update re-asserts Reading", async () => {
-    // The island sends only what changed, so `startedAt` is absent here. It
-    // must not be re-stamped to today over a date the user already has.
-    const original = baseRecord({ status: ABANDONED, startedAt: "2026-03-01T09:00:00.000Z" });
+  it("keeps the start date when a partial update touches a book already Reading", async () => {
+    // The common case: a rating or review save carries no dates at all.
+    const original = baseRecord({ status: READING, startedAt: "2026-03-01T09:00:00.000Z" });
     const { agent } = fakePds({ value: original, cid: "cid0" });
-    await seedRow(original, "cid0", { status: ABANDONED, startedAt: "2026-03-01T09:00:00.000Z" });
+    await seedRow(original, "cid0", { status: READING, startedAt: "2026-03-01T09:00:00.000Z" });
 
+    const { book } = await updateBookRecord({ ctx, agent, hiveId: HIVE_ID, updates: { stars: 8 } });
+
+    expect(book.startedAt).toBe("2026-03-01T09:00:00.000Z");
+    expect(book.status).toBe(READING);
+  });
+
+  it("keeps the start date when progress is saved on a book already Reading", async () => {
+    const original = baseRecord({ status: READING, startedAt: "2026-03-01T09:00:00.000Z" });
+    const { agent } = fakePds({ value: original, cid: "cid0" });
+    await seedRow(original, "cid0", { status: READING, startedAt: "2026-03-01T09:00:00.000Z" });
+
+    // `/api/update-book` forces READING onto any progress write.
     const { book } = await updateBookRecord({
       ctx,
       agent,
       hiveId: HIVE_ID,
-      updates: { status: READING },
+      updates: {
+        status: READING,
+        bookProgress: { currentPage: 40, updatedAt: "2026-08-20T00:00:00.000Z" },
+      },
     });
 
-    expect(book.status).toBe(READING);
     expect(book.startedAt).toBe("2026-03-01T09:00:00.000Z");
   });
 
-  it("keeps the recorded finish date when a partial update re-asserts Read", async () => {
-    const original = baseRecord({ status: ABANDONED, finishedAt: "2026-04-02T09:00:00.000Z" });
+  it("stamps a fresh finish date when a book is finished again after an earlier read", async () => {
+    // Dates left over from a previous read must not be presented as this one.
+    const original = baseRecord({
+      status: READING,
+      startedAt: "2026-05-01T09:00:00.000Z",
+      finishedAt: "2020-02-01T09:00:00.000Z",
+    });
     const { agent } = fakePds({ value: original, cid: "cid0" });
-    await seedRow(original, "cid0", { status: ABANDONED, finishedAt: "2026-04-02T09:00:00.000Z" });
+    await seedRow(original, "cid0", {
+      status: READING,
+      startedAt: "2026-05-01T09:00:00.000Z",
+      finishedAt: "2020-02-01T09:00:00.000Z",
+    });
 
     const { book } = await updateBookRecord({
       ctx,
@@ -453,7 +475,8 @@ describe("updateBookRecord", () => {
       updates: { status: FINISHED },
     });
 
-    expect(book.finishedAt).toBe("2026-04-02T09:00:00.000Z");
+    expect(book.finishedAt).not.toBe("2020-02-01T09:00:00.000Z");
+    expect(new Date(book.finishedAt!).getUTCFullYear()).toBeGreaterThan(2020);
   });
 
   it("still stamps a start date when the book has none", async () => {
@@ -469,6 +492,48 @@ describe("updateBookRecord", () => {
     });
 
     expect(book.startedAt).toBeTruthy();
+  });
+
+  it("does not downgrade a finished book when only a date is edited", async () => {
+    // The island sends `{ startedAt }` alone; reading that as "no status" used
+    // to infer Reading and write it over the user's Finished.
+    const original = baseRecord({
+      status: FINISHED,
+      startedAt: "2026-02-01T09:00:00.000Z",
+      finishedAt: "2026-03-01T09:00:00.000Z",
+    });
+    const { agent } = fakePds({ value: original, cid: "cid0" });
+    await seedRow(original, "cid0", {
+      status: FINISHED,
+      startedAt: "2026-02-01T09:00:00.000Z",
+      finishedAt: "2026-03-01T09:00:00.000Z",
+    });
+
+    const { book } = await updateBookRecord({
+      ctx,
+      agent,
+      hiveId: HIVE_ID,
+      updates: { startedAt: "2026-02-05" },
+    });
+
+    expect(book.status).toBe(FINISHED);
+    expect(book.finishedAt).toBe("2026-03-01T09:00:00.000Z");
+    expect(book.startedAt?.startsWith("2026-02-05")).toBe(true);
+  });
+
+  it("still infers Reading when a start date is set on a want-to-read book", async () => {
+    const original = baseRecord({ status: WANTTOREAD });
+    const { agent } = fakePds({ value: original, cid: "cid0" });
+    await seedRow(original, "cid0");
+
+    const { book } = await updateBookRecord({
+      ctx,
+      agent,
+      hiveId: HIVE_ID,
+      updates: { startedAt: "2026-02-05" },
+    });
+
+    expect(book.status).toBe(READING);
   });
 
   it("refuses to create over an existing rkey when the record cannot be read", async () => {

--- a/src/utils/getBook.test.ts
+++ b/src/utils/getBook.test.ts
@@ -390,18 +390,11 @@ describe("updateBookRecord", () => {
     expect(names()).toEqual(["putRecord"]);
   });
 
-  it("drops a follow-up patch that loses the CAS race", async () => {
-    const server = Bun.serve({
-      port: 0,
-      fetch: () =>
-        new Response(
-          Buffer.from(
-            "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNkYPhfDwAChwGA60e6kgAAAABJRU5ErkJggg==",
-            "base64",
-          ),
-          { headers: { "content-type": "image/png" } },
-        ),
-    });
+  it("re-reads and re-applies the patch after losing the CAS race", async () => {
+    // The common race: the user's next edit (a rating click) lands while the
+    // cover is still uploading. Dropping the patch here lost the cover for
+    // good — no later write re-supplies it.
+    const server = coverServer();
     try {
       const { pds, agent, names } = fakePds();
       const { followUp } = await updateBookRecord({
@@ -411,12 +404,57 @@ describe("updateBookRecord", () => {
         updates: { status: WANTTOREAD, coverImage: `${server.url}cover.png` },
       });
       // Someone else writes before the cover lands.
-      pds.record = { value: pds.record!.value, cid: "cid-elsewhere" };
+      pds.record = { value: { ...pds.record!.value, stars: 9 }, cid: "cid-elsewhere" };
 
-      await expect(followUp).resolves.toBe("conflict");
-      expect(names()).toEqual(["createRecord", "uploadBlob", "putRecord"]);
+      await expect(followUp).resolves.toBe("completed");
+      expect(names()).toEqual([
+        "createRecord",
+        "uploadBlob",
+        "putRecord",
+        "getRecord",
+        "putRecord",
+      ]);
+      // The winner's change survives, with the cover patched on top of it.
+      expect(pds.record?.value.stars).toBe(9);
+      expect(pds.record?.value.cover).toEqual(COVER as BookRecordValue["cover"]);
+      // The blob was uploaded once; only the write retried.
+      expect(pds.blobsUploaded).toBe(1);
+      // The row was not ours to update (its cid predates the winner); the
+      // user's next write CAS-fails once, re-reads, and self-heals.
       const row = await getUserBook({ ctx, agent, hiveId: HIVE_ID });
       expect(row?.cid).toBe("cid1");
+    } finally {
+      await server.stop(true);
+    }
+  });
+
+  it("gives up as a conflict when the CAS race never resolves", async () => {
+    const server = coverServer();
+    try {
+      const { agent, names } = fakePds();
+      const { followUp, userBook } = await updateBookRecord({
+        ctx,
+        agent,
+        hiveId: HIVE_ID,
+        updates: { status: WANTTOREAD, coverImage: `${server.url}cover.png` },
+      });
+      // A pathological PDS that refuses every swap, however fresh the cid.
+      let putAttempts = 0;
+      const rawPost = agent.post.bind(agent);
+      (agent as { post: unknown }).post = async (name: string, opts?: Record<string, unknown>) => {
+        if (name === "com.atproto.repo.putRecord") {
+          putAttempts++;
+          return { ok: false, data: { error: "InvalidSwap", message: "never" } };
+        }
+        return rawPost(name as Parameters<typeof rawPost>[0], opts as never);
+      };
+
+      await expect(followUp).resolves.toBe("conflict");
+      // Bounded: three write attempts, a re-read between each.
+      expect(putAttempts).toBe(3);
+      expect(names().filter((n) => n === "getRecord")).toHaveLength(2);
+      const row = await getUserBook({ ctx, agent, hiveId: HIVE_ID });
+      expect(row?.cid).toBe(userBook.cid);
       expect(row?.record?.cover).toBeUndefined();
     } finally {
       await server.stop(true);

--- a/src/utils/getBook.test.ts
+++ b/src/utils/getBook.test.ts
@@ -341,6 +341,19 @@ describe("updateBookRecord", () => {
     }
   });
 
+  it("refuses to create over an existing rkey when the record cannot be read", async () => {
+    // Pre-025 row (no stored record) whose record the PDS will not give us.
+    const { agent, names } = fakePds();
+    await seedRow(null, "cid0");
+
+    await expect(
+      updateBookRecord({ ctx, agent, hiveId: HIVE_ID, updates: { status: FINISHED } }),
+    ).rejects.toThrow(/could not read the current record/);
+
+    // A create here would have written over whatever is actually at that rkey.
+    expect(names()).toEqual(["getRecord"]);
+  });
+
   it("surfaces a write failure that is not a swap conflict", async () => {
     const original = baseRecord();
     const { agent } = fakePds({ value: original, cid: "cid0" });

--- a/src/utils/getBook.test.ts
+++ b/src/utils/getBook.test.ts
@@ -1,0 +1,424 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { Database as DatabaseSync } from "bun:sqlite";
+import { Kysely, SqliteDialect } from "kysely";
+import { createStorage } from "unstorage";
+import memoryDriver from "unstorage/drivers/memory";
+
+import type { SessionClient } from "../auth/client";
+import { wrapBunSqliteForKysely } from "../bun-sqlite-kysely";
+import type { BookUtilContext } from "../context";
+import { FINISHED, READING, WANTTOREAD } from "../constants";
+import { migrateToLatest, type Database, type DatabaseSchema } from "../db";
+import type { BookRecordValue, HiveId } from "../types";
+import { getBookRecord, getUserBook, updateBookRecord } from "./getBook";
+import { recordFromUserBook } from "./userBookStore";
+import { toUserBookView } from "./userBookView";
+
+const DID = "did:plc:testuser";
+const HIVE_ID = "bk_dune" as HiveId;
+const RKEY = "3kabc";
+const URI = `at://${DID}/buzz.bookhive.book/${RKEY}`;
+const COVER = {
+  $type: "blob",
+  ref: { $link: "bafkreigh2akiscaildcqabsyg3dfr6chu3fgpregiymsck7e7aqa4s52zy" },
+  mimeType: "image/jpeg",
+  size: 10,
+};
+
+async function createTestDb(): Promise<Database> {
+  const sqlite = new DatabaseSync(":memory:");
+  const db = new Kysely<DatabaseSchema>({
+    dialect: new SqliteDialect({ database: wrapBunSqliteForKysely(sqlite) }),
+  });
+  await migrateToLatest(db, sqlite);
+  return db;
+}
+
+type Call = { name: string; input: Record<string, unknown> };
+
+/**
+ * A PDS that holds one record and enforces `swapRecord`. `getRecord` answers
+ * from `pds.record`; `putRecord` only lands when the swap matches `pds.cid`.
+ */
+function fakePds(initial?: { value: BookRecordValue; cid: string }) {
+  const pds = {
+    record: initial ?? null,
+    calls: [] as Call[],
+    nextCid: 1,
+    blobsUploaded: 0,
+  };
+  const agent: SessionClient = {
+    did: DID,
+    async get(name, opts) {
+      pds.calls.push({ name, input: (opts?.["params"] ?? {}) as Record<string, unknown> });
+      if (name === "com.atproto.repo.getRecord") {
+        if (!pds.record) return { ok: false, data: { error: "RecordNotFound" } };
+        return { ok: true, data: { uri: URI, cid: pds.record.cid, value: pds.record.value } };
+      }
+      throw new Error(`unexpected get ${name}`);
+    },
+    async post(name, opts) {
+      const input = (opts?.["input"] ?? {}) as Record<string, unknown>;
+      pds.calls.push({ name, input });
+      const commit = () => {
+        const cid = `cid${pds.nextCid++}`;
+        pds.record = { value: input["record"] as BookRecordValue, cid };
+        return { ok: true as const, data: { uri: URI, cid } };
+      };
+      switch (name) {
+        case "com.atproto.repo.createRecord":
+          return commit();
+        case "com.atproto.repo.putRecord":
+          if (input["swapRecord"] !== pds.record?.cid) {
+            return {
+              ok: false,
+              data: { error: "InvalidSwap", message: "Record was at wrong CID" },
+            };
+          }
+          return commit();
+        case "com.atproto.repo.uploadBlob":
+          pds.blobsUploaded++;
+          return { ok: true, data: { blob: COVER } };
+        default:
+          throw new Error(`unexpected post ${name}`);
+      }
+    },
+  };
+  const names = () => pds.calls.map((c) => c.name.replace("com.atproto.repo.", ""));
+  return { pds, agent, names };
+}
+
+const baseRecord = (over: Partial<BookRecordValue> = {}): BookRecordValue => ({
+  $type: "buzz.bookhive.book",
+  title: "Dune",
+  authors: "Frank Herbert",
+  hiveId: HIVE_ID,
+  createdAt: "2026-01-01T00:00:00.000Z",
+  status: WANTTOREAD,
+  owned: true,
+  cover: COVER as BookRecordValue["cover"],
+  identifiers: { isbn13: "9780441013593" },
+  hiveBookUri: "at://did:plc:bookhive/buzz.bookhive.hiveBook/dune",
+  ...over,
+});
+
+describe("updateBookRecord", () => {
+  let db: Database;
+  let ctx: BookUtilContext;
+  let wide: Record<string, unknown>;
+
+  beforeEach(async () => {
+    db = await createTestDb();
+    wide = {};
+    ctx = {
+      db,
+      kv: createStorage({ driver: memoryDriver() }),
+      serviceAccountAgent: null,
+      addWideEventContext: (fields) => Object.assign(wide, fields),
+    };
+    await db
+      .insertInto("hive_book")
+      .values({
+        id: HIVE_ID as never,
+        title: "Dune",
+        rawTitle: "Dune",
+        authors: "Frank Herbert",
+        source: "goodreads",
+        thumbnail: "",
+        cover: "http://127.0.0.1:1/cover.jpg",
+        createdAt: new Date().toISOString(),
+        updatedAt: new Date().toISOString(),
+      } as never)
+      .execute();
+  });
+
+  afterEach(async () => {
+    await db.destroy();
+  });
+
+  async function seedRow(record: BookRecordValue | null, cid: string, columns: object = {}) {
+    await db
+      .insertInto("user_book")
+      .values({
+        uri: URI,
+        cid,
+        userDid: DID,
+        hiveId: HIVE_ID,
+        title: "Dune",
+        authors: "Frank Herbert",
+        status: WANTTOREAD,
+        owned: 1,
+        createdAt: "2026-01-01T00:00:00.000Z",
+        indexedAt: "2026-01-01T00:00:00.000Z",
+        record: record ? JSON.stringify(record) : null,
+        ...columns,
+      })
+      .execute();
+  }
+
+  it("merges locally and writes once with a CAS on the row's cid", async () => {
+    const original = baseRecord();
+    const { pds, agent, names } = fakePds({ value: original, cid: "cid0" });
+    await seedRow(original, "cid0");
+
+    const { book, userBook } = await updateBookRecord({
+      ctx,
+      agent,
+      hiveId: HIVE_ID,
+      updates: { status: FINISHED },
+    });
+
+    expect(names()).toEqual(["putRecord"]);
+    expect(pds.calls[0]!.input["swapRecord"]).toBe("cid0");
+    expect(wide["book_merge_source"]).toBe("local");
+
+    expect(book.status).toBe(FINISHED);
+    expect(book.finishedAt).toBeTruthy();
+    // Fields only the record holds survive a merge that never read the PDS.
+    expect(book.cover).toEqual(original.cover);
+    expect(book.identifiers).toEqual(original.identifiers);
+    expect(book.hiveBookUri).toBe(original.hiveBookUri!);
+
+    expect(userBook.cid).toBe("cid1");
+    const row = await getUserBook({ ctx, agent, hiveId: HIVE_ID });
+    expect(row?.cid).toBe("cid1");
+    expect(row?.status).toBe(FINISHED);
+    expect(row?.record?.cover).toEqual(original.cover);
+  });
+
+  it("reads the PDS when the row predates the record column", async () => {
+    const original = baseRecord({ stars: 8 });
+    const { pds, agent, names } = fakePds({ value: original, cid: "cid0" });
+    await seedRow(null, "cid0");
+
+    const { book } = await updateBookRecord({
+      ctx,
+      agent,
+      hiveId: HIVE_ID,
+      updates: { status: READING },
+    });
+
+    expect(names()).toEqual(["getRecord", "putRecord"]);
+    expect(pds.calls[0]!.input["cid"]).toBeUndefined();
+    expect(pds.calls[1]!.input["swapRecord"]).toBe("cid0");
+    expect(wide["book_merge_source"]).toBe("pds");
+    expect(book.stars).toBe(8);
+
+    const row = await getUserBook({ ctx, agent, hiveId: HIVE_ID });
+    expect(row?.record).not.toBeNull();
+  });
+
+  it("re-merges against the PDS after a CAS conflict instead of overwriting", async () => {
+    const stale = baseRecord();
+    // Another client rated the book since our row last saw it.
+    const current = baseRecord({ stars: 9, review: "Spice." });
+    const { pds, agent, names } = fakePds({ value: current, cid: "cid-other" });
+    await seedRow(stale, "cid0");
+
+    const { book, userBook } = await updateBookRecord({
+      ctx,
+      agent,
+      hiveId: HIVE_ID,
+      updates: { status: FINISHED },
+    });
+
+    expect(names()).toEqual(["putRecord", "getRecord", "putRecord"]);
+    expect(pds.calls[0]!.input["swapRecord"]).toBe("cid0");
+    expect(pds.calls[2]!.input["swapRecord"]).toBe("cid-other");
+    expect(wide["book_merge_source"]).toBe("pds_after_conflict");
+    expect(book.status).toBe(FINISHED);
+    expect(book.stars).toBe(9);
+    expect(book.review).toBe("Spice.");
+    expect(userBook.cid).toBe("cid1");
+  });
+
+  it("lets local columns win over the stored record", async () => {
+    const record = baseRecord();
+    const { agent } = fakePds({ value: record, cid: "cid0" });
+    // KOSync wrote progress to the row; the PDS write for it is still queued.
+    const progress = { percent: 40, updatedAt: "2026-02-01T00:00:00.000Z" };
+    await seedRow(record, "cid0", { bookProgress: JSON.stringify(progress), status: READING });
+
+    const { book } = await updateBookRecord({
+      ctx,
+      agent,
+      hiveId: HIVE_ID,
+      updates: { stars: 7 },
+    });
+
+    expect(book.status).toBe(READING);
+    expect(book.bookProgress?.percent).toBe(40);
+    expect(book.stars).toBe(7);
+  });
+
+  it("creates without an inline cover upload and patches the cover afterwards", async () => {
+    const server = Bun.serve({
+      port: 0,
+      fetch: () =>
+        new Response(
+          Buffer.from(
+            "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNkYPhfDwAChwGA60e6kgAAAABJRU5ErkJggg==",
+            "base64",
+          ),
+          { headers: { "content-type": "image/png" } },
+        ),
+    });
+    try {
+      const { pds, agent, names } = fakePds();
+
+      const { book, userBook, followUp } = await updateBookRecord({
+        ctx,
+        agent,
+        hiveId: HIVE_ID,
+        updates: { status: WANTTOREAD, coverImage: `${server.url}cover.png` },
+      });
+
+      // The request path: one create, nothing else.
+      expect(names()).toEqual(["createRecord"]);
+      expect(book.cover).toBeUndefined();
+      expect(userBook.cid).toBe("cid1");
+
+      await expect(followUp).resolves.toBe("completed");
+      expect(names()).toEqual(["createRecord", "uploadBlob", "putRecord"]);
+      expect(pds.calls[2]!.input["swapRecord"]).toBe("cid1");
+      expect(pds.record?.value.cover).toEqual(COVER as BookRecordValue["cover"]);
+
+      const row = await getUserBook({ ctx, agent, hiveId: HIVE_ID });
+      expect(row?.cid).toBe("cid2");
+      expect(row?.record?.cover).toEqual(COVER as BookRecordValue["cover"]);
+      expect(row?.status).toBe(WANTTOREAD);
+    } finally {
+      await server.stop(true);
+    }
+  });
+
+  it("skips the follow-up when the record is already complete", async () => {
+    const original = baseRecord();
+    const { agent, names } = fakePds({ value: original, cid: "cid0" });
+    await seedRow(original, "cid0");
+
+    const { followUp } = await updateBookRecord({
+      ctx,
+      agent,
+      hiveId: HIVE_ID,
+      updates: { stars: 10, coverImage: "http://127.0.0.1:1/never-fetched.jpg" },
+    });
+
+    await expect(followUp).resolves.toBe("nothing");
+    expect(names()).toEqual(["putRecord"]);
+  });
+
+  it("drops a follow-up patch that loses the CAS race", async () => {
+    const server = Bun.serve({
+      port: 0,
+      fetch: () =>
+        new Response(
+          Buffer.from(
+            "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNkYPhfDwAChwGA60e6kgAAAABJRU5ErkJggg==",
+            "base64",
+          ),
+          { headers: { "content-type": "image/png" } },
+        ),
+    });
+    try {
+      const { pds, agent, names } = fakePds();
+      const { followUp } = await updateBookRecord({
+        ctx,
+        agent,
+        hiveId: HIVE_ID,
+        updates: { status: WANTTOREAD, coverImage: `${server.url}cover.png` },
+      });
+      // Someone else writes before the cover lands.
+      pds.record = { value: pds.record!.value, cid: "cid-elsewhere" };
+
+      await expect(followUp).resolves.toBe("conflict");
+      expect(names()).toEqual(["createRecord", "uploadBlob", "putRecord"]);
+      const row = await getUserBook({ ctx, agent, hiveId: HIVE_ID });
+      expect(row?.cid).toBe("cid1");
+      expect(row?.record?.cover).toBeUndefined();
+    } finally {
+      await server.stop(true);
+    }
+  });
+
+  it("surfaces a write failure that is not a swap conflict", async () => {
+    const original = baseRecord();
+    const { agent } = fakePds({ value: original, cid: "cid0" });
+    await seedRow(original, "cid0");
+    agent.post = async () => ({ ok: false, data: { error: "RateLimitExceeded" } });
+
+    await expect(
+      updateBookRecord({ ctx, agent, hiveId: HIVE_ID, updates: { status: FINISHED } }),
+    ).rejects.toThrow(/RateLimitExceeded/);
+  });
+});
+
+describe("getBookRecord", () => {
+  it("returns the current cid alongside the value", async () => {
+    const original = baseRecord();
+    const { agent } = fakePds({ value: original, cid: "cid7" });
+    const res = await getBookRecord({ agent, uri: URI });
+    expect(res?.cid).toBe("cid7");
+    expect(res?.value.title).toBe("Dune");
+  });
+});
+
+describe("recordFromUserBook", () => {
+  const row = {
+    uri: URI,
+    cid: "cid0",
+    userDid: DID,
+    hiveId: HIVE_ID,
+    title: "Dune",
+    authors: "Frank Herbert",
+    createdAt: "2026-01-01T00:00:00.000Z",
+    indexedAt: "2026-01-01T00:00:00.000Z",
+    status: READING,
+    owned: 0,
+    startedAt: null,
+    finishedAt: null,
+    stars: null,
+    review: null,
+    bookProgress: null,
+    previousReads: null,
+  };
+
+  it("is null without a stored record", () => {
+    expect(recordFromUserBook({ ...row, record: null })).toBeNull();
+  });
+
+  it("keeps an old record's unset owned unset, but honours a column 1", () => {
+    const record = baseRecord({ owned: undefined });
+    expect(recordFromUserBook({ ...row, record })?.owned).toBeUndefined();
+    expect(recordFromUserBook({ ...row, owned: 1, record })?.owned).toBe(true);
+    expect(recordFromUserBook({ ...row, record: baseRecord({ owned: true }) })?.owned).toBe(false);
+  });
+});
+
+describe("toUserBookView", () => {
+  it("exposes owned as a boolean and hides the raw record", () => {
+    const view = toUserBookView({
+      uri: URI,
+      cid: "cid0",
+      userDid: DID,
+      hiveId: HIVE_ID,
+      title: "Dune",
+      authors: "Frank Herbert",
+      createdAt: "2026-01-01T00:00:00.000Z",
+      indexedAt: "2026-01-01T00:00:00.000Z",
+      status: READING,
+      owned: 1,
+      startedAt: null,
+      finishedAt: null,
+      stars: 8,
+      review: null,
+      bookProgress: null,
+      previousReads: null,
+      record: baseRecord(),
+    });
+    expect(view.owned).toBe(true);
+    expect(view.stars).toBe(8);
+    expect("record" in view).toBe(false);
+    expect("userDid" in view).toBe(false);
+  });
+});

--- a/src/utils/getBook.ts
+++ b/src/utils/getBook.ts
@@ -311,6 +311,18 @@ export async function updateBookRecord({
     ctx.addWideEventContext({ book_merge_source: local ? "local" : "pds" });
   }
 
+  // A row whose record we could not read (pre-025 and the PDS read failed or
+  // the stored record no longer validates) still knows the book's identity.
+  // Without this the merge has no title/authors and every write 400s.
+  if (userBook && !original) {
+    Object.assign(recordUpdates, {
+      title: userBook.title,
+      authors: userBook.authors,
+      createdAt: userBook.createdAt,
+      ...recordUpdates,
+    });
+  }
+
   let coverSource = coverImage;
   if (!original && !userBook) {
     const hiveBook = await ctx.db
@@ -346,6 +358,12 @@ export async function updateBookRecord({
 
   let record = build(original?.value ?? null);
   const rkey = userBook ? userBook.uri.split("/").at(-1)! : TID.now();
+  // `swapRecord: null` is a create. A row with a URI already has a record at
+  // this rkey, so falling into the create branch because we could not read it
+  // would write over whatever is actually there.
+  if (userBook && !original) {
+    throw new Error(`Failed to record book: could not read the current record for ${hiveId}`);
+  }
   let written = await writeBookRecord({
     agent,
     rkey,

--- a/src/utils/getBook.ts
+++ b/src/utils/getBook.ts
@@ -71,7 +71,14 @@ function inferBookStatusAndDates(
     startedAt?: string;
     finishedAt?: string;
   },
-  { skipAutoDate = false }: { skipAutoDate?: boolean } = {},
+  {
+    skipAutoDate = false,
+    existing,
+  }: {
+    skipAutoDate?: boolean;
+    /** Dates the record already carries, so a partial update can't restamp them. */
+    existing?: { startedAt?: string | undefined; finishedAt?: string | undefined };
+  } = {},
 ): {
   status: string | undefined;
   startedAt: string | undefined;
@@ -100,10 +107,18 @@ function inferBookStatusAndDates(
   // Use the current full timestamp so we record when the action happened,
   // matching the behavior of createdAt.
   // Imports pass skipAutoDate to avoid stamping today when the source has no date.
+  // "if not already provided" means by the caller *or* by the record. The
+  // island sends only what changed, so a status click carries no dates — and
+  // stamping today over the date the user already has silently rewrites their
+  // reading history on their PDS.
   if (!skipAutoDate) {
-    if (autoStatus === BOOK_STATUS.READING && !updates.startedAt) {
+    if (autoStatus === BOOK_STATUS.READING && !updates.startedAt && !existing?.startedAt) {
       autoStartedAt = new Date().toISOString();
-    } else if (autoStatus === BOOK_STATUS.FINISHED && !updates.finishedAt) {
+    } else if (
+      autoStatus === BOOK_STATUS.FINISHED &&
+      !updates.finishedAt &&
+      !existing?.finishedAt
+    ) {
       autoFinishedAt = new Date().toISOString();
     }
   }
@@ -139,11 +154,16 @@ export async function getBookRecord({
     },
   });
   const payload = res.ok ? (res.data as { value?: unknown; cid?: string }) : null;
-  const parsed = payload?.value ? BookRecord.validateRecord(payload.value) : null;
-  if (!parsed?.success || !payload?.cid) {
-    return null;
-  }
-  return { value: parsed.value, cid: payload.cid };
+  // Both are required: without a cid there is nothing to compare-and-swap on.
+  if (!payload?.value || !payload.cid) return null;
+  const parsed = BookRecord.validateRecord(payload.value);
+  // A record that fails our validator is still the record the user has, and
+  // merging onto it is how a bad field gets healed by the write that
+  // overwrites it. Refusing would make that book permanently unwritable.
+  return {
+    value: (parsed.success ? parsed.value : payload.value) as BookRecord.Record,
+    cid: payload.cid,
+  };
 }
 
 /** Pure, so a CAS conflict can re-run it against what the PDS actually holds. */
@@ -198,7 +218,13 @@ function buildBookRecord({
           startedAt: updates.startedAt,
           finishedAt: updates.finishedAt,
         },
-        { skipAutoDate },
+        {
+          skipAutoDate,
+          existing: {
+            startedAt: originalBook?.startedAt,
+            finishedAt: originalBook?.finishedAt,
+          },
+        },
       );
 
   if (autoStartedAt && autoFinishedAt) {
@@ -311,16 +337,12 @@ export async function updateBookRecord({
     ctx.addWideEventContext({ book_merge_source: local ? "local" : "pds" });
   }
 
-  // A row whose record we could not read (pre-025 and the PDS read failed or
-  // the stored record no longer validates) still knows the book's identity.
-  // Without this the merge has no title/authors and every write 400s.
+  // A row with a URI already has a record at that rkey, so we must not fall
+  // through to the create branch below. Bail before building anything, so the
+  // reason surfaces instead of a downstream validation error masking it.
   if (userBook && !original) {
-    Object.assign(recordUpdates, {
-      title: userBook.title,
-      authors: userBook.authors,
-      createdAt: userBook.createdAt,
-      ...recordUpdates,
-    });
+    ctx.addWideEventContext({ book_record_read: "unusable" });
+    throw new Error(`Failed to record book: could not read the current record for ${hiveId}`);
   }
 
   let coverSource = coverImage;
@@ -358,12 +380,6 @@ export async function updateBookRecord({
 
   let record = build(original?.value ?? null);
   const rkey = userBook ? userBook.uri.split("/").at(-1)! : TID.now();
-  // `swapRecord: null` is a create. A row with a URI already has a record at
-  // this rkey, so falling into the create branch because we could not read it
-  // would write over whatever is actually there.
-  if (userBook && !original) {
-    throw new Error(`Failed to record book: could not read the current record for ${hiveId}`);
-  }
   let written = await writeBookRecord({
     agent,
     rkey,
@@ -475,7 +491,13 @@ export async function updateBookRecords({
         startedAt: update.startedAt,
         finishedAt: update.finishedAt,
       },
-      { skipAutoDate },
+      {
+        skipAutoDate,
+        existing: {
+          startedAt: originalBook?.startedAt,
+          finishedAt: originalBook?.finishedAt,
+        },
+      },
     );
 
     if (autoStartedAt && autoFinishedAt) {

--- a/src/utils/getBook.ts
+++ b/src/utils/getBook.ts
@@ -76,8 +76,12 @@ function inferBookStatusAndDates(
     existing,
   }: {
     skipAutoDate?: boolean;
-    /** Dates the record already carries, so a partial update can't restamp them. */
-    existing?: { startedAt?: string | undefined; finishedAt?: string | undefined };
+    /** What the record already says, so a partial update can't rewrite it. */
+    existing?: {
+      status?: string | undefined;
+      startedAt?: string | undefined;
+      finishedAt?: string | undefined;
+    };
   } = {},
 ): {
   status: string | undefined;
@@ -88,17 +92,22 @@ function inferBookStatusAndDates(
   let autoFinishedAt = updates.finishedAt;
   let autoStatus = updates.status;
 
+  // "unset" must mean unset on the *record*, not merely absent from this
+  // payload: the island posts only what changed, so reading a missing status
+  // as "none" downgraded a finished book to Reading on a date edit.
+  const currentStatus = updates.status ?? existing?.status;
+
   // If user sets startedAt and status is "want to read" or unset, infer they're reading
-  if (updates.startedAt && (!updates.status || updates.status === BOOK_STATUS.WANTTOREAD)) {
+  if (updates.startedAt && (!currentStatus || currentStatus === BOOK_STATUS.WANTTOREAD)) {
     autoStatus = BOOK_STATUS.READING;
   }
 
   // If user sets finishedAt and status is "want to read", "reading", or unset, infer they're finished
   if (
     updates.finishedAt &&
-    (!updates.status ||
-      updates.status === BOOK_STATUS.WANTTOREAD ||
-      updates.status === BOOK_STATUS.READING)
+    (!currentStatus ||
+      currentStatus === BOOK_STATUS.WANTTOREAD ||
+      currentStatus === BOOK_STATUS.READING)
   ) {
     autoStatus = BOOK_STATUS.FINISHED;
   }
@@ -107,18 +116,15 @@ function inferBookStatusAndDates(
   // Use the current full timestamp so we record when the action happened,
   // matching the behavior of createdAt.
   // Imports pass skipAutoDate to avoid stamping today when the source has no date.
-  // "if not already provided" means by the caller *or* by the record. The
-  // island sends only what changed, so a status click carries no dates — and
-  // stamping today over the date the user already has silently rewrites their
-  // reading history on their PDS.
+  // Stamp when a book *enters* a status, not whenever it is in one: a rating
+  // save on an already-Reading book carries no dates and must not restamp
+  // them, while a book finished in 2020 and read again now must not keep 2020.
+  const alreadyReading = existing?.status === BOOK_STATUS.READING && !!existing.startedAt;
+  const alreadyFinished = existing?.status === BOOK_STATUS.FINISHED && !!existing.finishedAt;
   if (!skipAutoDate) {
-    if (autoStatus === BOOK_STATUS.READING && !updates.startedAt && !existing?.startedAt) {
+    if (autoStatus === BOOK_STATUS.READING && !updates.startedAt && !alreadyReading) {
       autoStartedAt = new Date().toISOString();
-    } else if (
-      autoStatus === BOOK_STATUS.FINISHED &&
-      !updates.finishedAt &&
-      !existing?.finishedAt
-    ) {
+    } else if (autoStatus === BOOK_STATUS.FINISHED && !updates.finishedAt && !alreadyFinished) {
       autoFinishedAt = new Date().toISOString();
     }
   }
@@ -135,10 +141,7 @@ function inferBookStatusAndDates(
   };
 }
 
-/**
- * Current version of the record on the PDS. Not pinned to a cid: a stale pin
- * 404s, which used to read as "no record" and produce a duplicate create.
- */
+/** Current record on the PDS. Not pinned to a cid: a stale pin 404s and looked like "no record". */
 export async function getBookRecord({
   agent,
   uri,
@@ -154,12 +157,11 @@ export async function getBookRecord({
     },
   });
   const payload = res.ok ? (res.data as { value?: unknown; cid?: string }) : null;
-  // Both are required: without a cid there is nothing to compare-and-swap on.
+  // A cid is required: there is nothing to compare-and-swap on without one.
   if (!payload?.value || !payload.cid) return null;
+  // A record failing our validator is still the user's record; merging onto it
+  // is how the offending field gets overwritten. Refusing bricks the book.
   const parsed = BookRecord.validateRecord(payload.value);
-  // A record that fails our validator is still the record the user has, and
-  // merging onto it is how a bad field gets healed by the write that
-  // overwrites it. Refusing would make that book permanently unwritable.
   return {
     value: (parsed.success ? parsed.value : payload.value) as BookRecord.Record,
     cid: payload.cid,
@@ -195,7 +197,7 @@ function buildBookRecord({
         startedAt: originalBook.startedAt,
         finishedAt: originalBook.finishedAt,
       },
-      ...(originalBook.previousReads ?? []),
+      ...(Array.isArray(originalBook.previousReads) ? originalBook.previousReads : []),
     ];
   }
 
@@ -221,6 +223,7 @@ function buildBookRecord({
         {
           skipAutoDate,
           existing: {
+            status: originalBook?.status,
             startedAt: originalBook?.startedAt,
             finishedAt: originalBook?.finishedAt,
           },
@@ -246,7 +249,7 @@ function buildBookRecord({
     authors: originalBook?.authors || updates.authors,
     hiveId: originalBook?.hiveId || hiveId,
     createdAt: originalBook?.createdAt || new Date().toISOString(),
-    // A missing cover is patched in off the request path (userBookFollowUp.ts).
+    // Patched in off the request path (userBookFollowUp.ts).
     cover: originalBook?.cover,
     // Always prefer new values (including auto-inferred status)
     status: finalStatus,
@@ -300,13 +303,11 @@ function buildBookRecord({
 }
 
 /**
- * Write one change to a book in the user's PDS and mirror it to `user_book`.
+ * Write one change to a book's PDS record and mirror it to `user_book`.
  *
- * Every status click goes through here, so it is one PDS round-trip: the
- * merge reads the local row (the PDS only on a pre-025 row or a CAS
- * conflict), and the cover blob and catalogue link — which BookHive never
- * renders from the record — are patched in after the response. `followUp`
- * is that deferred work; it never rejects.
+ * One PDS round-trip: the merge reads the local row (the PDS only on a pre-025
+ * row or a CAS conflict), and the cover and catalogue link are patched in
+ * afterwards by `followUp`, which never rejects.
  */
 export async function updateBookRecord({
   ctx,
@@ -337,9 +338,8 @@ export async function updateBookRecord({
     ctx.addWideEventContext({ book_merge_source: local ? "local" : "pds" });
   }
 
-  // A row with a URI already has a record at that rkey, so we must not fall
-  // through to the create branch below. Bail before building anything, so the
-  // reason surfaces instead of a downstream validation error masking it.
+  // A row with a URI has a record at that rkey; falling through to the create
+  // branch would write over it. Bail early so this reason isn't masked.
   if (userBook && !original) {
     ctx.addWideEventContext({ book_record_read: "unusable" });
     throw new Error(`Failed to record book: could not read the current record for ${hiveId}`);
@@ -494,6 +494,7 @@ export async function updateBookRecords({
       {
         skipAutoDate,
         existing: {
+          status: originalBook?.status,
           startedAt: originalBook?.startedAt,
           finishedAt: originalBook?.finishedAt,
         },

--- a/src/utils/getBook.ts
+++ b/src/utils/getBook.ts
@@ -11,7 +11,7 @@ import { findBookIdentifiersByLookup } from "../bsky/bookLookup";
 import { toBookIdentifiersOutput } from "./bookIdentifiers";
 import { uploadImageBlob } from "./uploadImageBlob";
 import { BOOK_STATUS } from "../constants";
-import { INVALID_SWAP, writeBookRecord } from "./bookRecordWrite";
+import { getBookRecord, INVALID_SWAP, writeBookRecord } from "./bookRecordWrite";
 import { ensureBookCataloged, getCatalogedBookUri } from "./ensureBookCataloged";
 import { completeUserBookRecord, type FollowUpOutcome } from "./userBookFollowUp";
 import {
@@ -23,6 +23,7 @@ import {
 
 // Re-exported: the import worker and its tests import these from here.
 export { getUserBook, updateUserBook } from "./userBookStore";
+export { getBookRecord } from "./bookRecordWrite";
 
 /**
  * Normalize a date string to a full ISO datetime.
@@ -138,33 +139,6 @@ function inferBookStatusAndDates(
     status: autoStatus,
     startedAt: autoStartedAt,
     finishedAt: autoFinishedAt,
-  };
-}
-
-/** Current record on the PDS. Not pinned to a cid: a stale pin 404s and looked like "no record". */
-export async function getBookRecord({
-  agent,
-  uri,
-}: {
-  agent: Pick<SessionClient, "did" | "get">;
-  uri: string;
-}): Promise<{ value: BookRecord.Record; cid: string } | null> {
-  const res = await agent.get("com.atproto.repo.getRecord", {
-    params: {
-      repo: agent.did,
-      collection: ids.BuzzBookhiveBook,
-      rkey: uri.split("/").at(-1)!,
-    },
-  });
-  const payload = res.ok ? (res.data as { value?: unknown; cid?: string }) : null;
-  // A cid is required: there is nothing to compare-and-swap on without one.
-  if (!payload?.value || !payload.cid) return null;
-  // A record failing our validator is still the user's record; merging onto it
-  // is how the offending field gets overwritten. Refusing bricks the book.
-  const parsed = BookRecord.validateRecord(payload.value);
-  return {
-    value: (parsed.success ? parsed.value : payload.value) as BookRecord.Record,
-    cid: payload.cid,
   };
 }
 

--- a/src/utils/getBook.ts
+++ b/src/utils/getBook.ts
@@ -6,13 +6,23 @@ import { parseISO, isValid } from "date-fns";
 
 import type { BookUtilContext } from "../context";
 import { ids, Book as BookRecord, Buzz as BuzzRecord } from "../bsky/lexicon";
-import type { HiveId, UserBook, UserBookRow } from "../types";
+import type { BookIdentifiers, HiveId, UserBook } from "../types";
 import { findBookIdentifiersByLookup } from "../bsky/bookLookup";
 import { toBookIdentifiersOutput } from "./bookIdentifiers";
 import { uploadImageBlob } from "./uploadImageBlob";
 import { BOOK_STATUS } from "../constants";
-import { hydrateUserBook, serializeUserBook } from "./bookProgress";
-import { ensureBookCataloged } from "./ensureBookCataloged";
+import { INVALID_SWAP, writeBookRecord } from "./bookRecordWrite";
+import { ensureBookCataloged, getCatalogedBookUri } from "./ensureBookCataloged";
+import { completeUserBookRecord, type FollowUpOutcome } from "./userBookFollowUp";
+import {
+  getUserBook,
+  recordFromUserBook,
+  updateUserBook,
+  userBookFromRecord,
+} from "./userBookStore";
+
+// Re-exported: the import worker and its tests import these from here.
+export { getUserBook, updateUserBook } from "./userBookStore";
 
 /**
  * Normalize a date string to a full ISO datetime.
@@ -110,132 +120,48 @@ function inferBookStatusAndDates(
   };
 }
 
-export async function getUserBook({
-  ctx,
-  agent,
-  hiveId,
-}: {
-  ctx: Pick<BookUtilContext, "db">;
-  agent: SessionClient;
-  hiveId: HiveId;
-}): Promise<UserBook | null> {
-  const rawUserBook = await ctx.db
-    .selectFrom("user_book")
-    .selectAll()
-    .where("userDid", "=", agent.did)
-    .where("hiveId", "=", hiveId)
-    .executeTakeFirst();
-
-  if (!rawUserBook) {
-    return null;
-  }
-
-  return hydrateUserBook(rawUserBook);
-}
-
-export async function updateUserBook({
-  ctx,
-  userBook,
-}: {
-  ctx: Pick<BookUtilContext, "db">;
-  userBook: UserBook;
-}): Promise<void> {
-  const row: UserBookRow = serializeUserBook(userBook);
-  await ctx.db
-    .insertInto("user_book")
-    .values(row)
-    .onConflict((oc) =>
-      oc.column("uri").doUpdateSet((c) => ({
-        indexedAt: c.ref("excluded.indexedAt"),
-        cid: c.ref("excluded.cid"),
-        authors: c.ref("excluded.authors"),
-        title: c.ref("excluded.title"),
-        hiveId: c.ref("excluded.hiveId"),
-        status: c.ref("excluded.status"),
-        owned: c.ref("excluded.owned"),
-        startedAt: c.ref("excluded.startedAt"),
-        finishedAt: c.ref("excluded.finishedAt"),
-        review: c.ref("excluded.review"),
-        stars: c.ref("excluded.stars"),
-        bookProgress: c.ref("excluded.bookProgress"),
-        previousReads: c.ref("excluded.previousReads"),
-      })),
-    )
-    .execute();
-}
 /**
- * Get a book from the user's PDS
+ * Current version of the record on the PDS. Not pinned to a cid: a stale pin
+ * 404s, which used to read as "no record" and produce a duplicate create.
  */
 export async function getBookRecord({
   agent,
-  cid,
   uri,
 }: {
-  agent: SessionClient;
-  cid: string;
+  agent: Pick<SessionClient, "did" | "get">;
   uri: string;
-}): Promise<BookRecord.Record | null> {
+}): Promise<{ value: BookRecord.Record; cid: string } | null> {
   const res = await agent.get("com.atproto.repo.getRecord", {
     params: {
       repo: agent.did,
       collection: ids.BuzzBookhiveBook,
       rkey: uri.split("/").at(-1)!,
-      cid,
     },
   });
-  const payload = res.ok ? (res.data as { value?: unknown }) : null;
-  const originalBook = payload?.value as BookRecord.Record | undefined;
-
-  if (!originalBook) {
+  const payload = res.ok ? (res.data as { value?: unknown; cid?: string }) : null;
+  const parsed = payload?.value ? BookRecord.validateRecord(payload.value) : null;
+  if (!parsed?.success || !payload?.cid) {
     return null;
   }
-
-  return originalBook;
+  return { value: parsed.value, cid: payload.cid };
 }
 
-/**
- * Update a book in the user's PDS
- */
-export async function updateBookRecord({
-  ctx,
-  agent,
-  hiveId,
+/** Pure, so a CAS conflict can re-run it against what the PDS actually holds. */
+function buildBookRecord({
+  originalBook,
   updates,
-  skipAutoDate = false,
+  hiveId,
+  identifiers,
+  hiveBookUri,
+  skipAutoDate,
 }: {
-  ctx: BookUtilContext;
-  agent: SessionClient;
+  originalBook: BookRecord.Record | null;
+  updates: Partial<BookRecord.Record>;
   hiveId: HiveId;
-  updates: Partial<BookRecord.Record> & { coverImage?: string };
-  skipAutoDate?: boolean;
-}): Promise<{ book: BookRecord.Record; userBook: UserBook }> {
-  const userBook = await getUserBook({ ctx, agent, hiveId });
-
-  let originalBook: BookRecord.Record | null = null;
-  if (userBook) {
-    originalBook = await getBookRecord({
-      agent,
-      cid: userBook.cid,
-      uri: userBook.uri,
-    });
-  }
-
-  if (!originalBook && !userBook) {
-    const hiveBook = await ctx.db
-      .selectFrom("hive_book")
-      .selectAll()
-      .where("id", "=", hiveId)
-      .executeTakeFirst();
-    if (hiveBook) {
-      Object.assign(updates, {
-        coverImage: (hiveBook.cover || hiveBook.thumbnail) as string,
-        title: hiveBook.title,
-        authors: hiveBook.authors,
-        ...updates,
-      });
-    }
-  }
-
+  identifiers: BookIdentifiers;
+  hiveBookUri: string | undefined;
+  skipAutoDate: boolean;
+}): BookRecord.Record {
   // Re-Read: selecting "Reading" on an already-finished book means the user
   // is starting another pass. Push the current started/finished dates into
   // previousReads (keeping existing history), then reset: status=Reading,
@@ -287,14 +213,6 @@ export async function updateBookRecord({
   // Determine the final status (use auto-inferred status or original status)
   const finalStatus = autoStatus || originalBook?.status;
 
-  const identifiersRow = await findBookIdentifiersByLookup({ ctx, hiveId });
-  const identifiers = toBookIdentifiersOutput(identifiersRow);
-
-  // Ensure the book is cataloged before writing to the user's PDS so we can embed
-  // hiveBookUri. Fast path (expected): already cataloged, one DB read, no network.
-  // Slow path (last resort): enrich + catalog with timeouts if it slipped through.
-  const hiveBookAtUri = await ensureBookCataloged(ctx, hiveId);
-
   const bookData = {
     $type: ids.BuzzBookhiveBook,
     // Always prefer original values
@@ -302,7 +220,8 @@ export async function updateBookRecord({
     authors: originalBook?.authors || updates.authors,
     hiveId: originalBook?.hiveId || hiveId,
     createdAt: originalBook?.createdAt || new Date().toISOString(),
-    cover: originalBook?.cover || (await uploadImageBlob(updates.coverImage, agent, 800)),
+    // A missing cover is patched in off the request path (userBookFollowUp.ts).
+    cover: originalBook?.cover,
     // Always prefer new values (including auto-inferred status)
     status: finalStatus,
     startedAt:
@@ -337,8 +256,8 @@ export async function updateBookRecord({
           : originalBook?.bookProgress,
     // Default to owned when first adding a book to library
     owned: updates.owned ?? originalBook?.owned ?? true,
-    identifiers: Object.keys(identifiers).length > 0 ? identifiers : undefined,
-    hiveBookUri: hiveBookAtUri ?? originalBook?.hiveBookUri,
+    identifiers: Object.keys(identifiers).length > 0 ? identifiers : originalBook?.identifiers,
+    hiveBookUri: hiveBookUri ?? originalBook?.hiveBookUri,
     // Preserve re-read history across partial updates (rating/review edits);
     // on a re-read request, replace it with the rotated list so the old dates
     // are archived in history and the book starts fresh.
@@ -351,63 +270,121 @@ export async function updateBookRecord({
     throw new Error("Book incomplete or invalid: " + book.error.message);
   }
 
-  const record = book.value as BookRecord.Record;
+  return book.value as BookRecord.Record;
+}
 
-  const response = await agent.post("com.atproto.repo.applyWrites", {
-    input: {
-      repo: agent.did,
-      writes: [
-        {
-          $type: originalBook
-            ? "com.atproto.repo.applyWrites#update"
-            : "com.atproto.repo.applyWrites#create",
-          collection: ids.BuzzBookhiveBook,
-          rkey: userBook ? userBook.uri.split("/").at(-1)! : TID.now(),
-          value: record,
-        },
-      ],
-    },
+/**
+ * Write one change to a book in the user's PDS and mirror it to `user_book`.
+ *
+ * Every status click goes through here, so it is one PDS round-trip: the
+ * merge reads the local row (the PDS only on a pre-025 row or a CAS
+ * conflict), and the cover blob and catalogue link — which BookHive never
+ * renders from the record — are patched in after the response. `followUp`
+ * is that deferred work; it never rejects.
+ */
+export async function updateBookRecord({
+  ctx,
+  agent,
+  hiveId,
+  updates,
+  skipAutoDate = false,
+}: {
+  ctx: BookUtilContext;
+  agent: SessionClient;
+  hiveId: HiveId;
+  updates: Partial<BookRecord.Record> & { coverImage?: string };
+  skipAutoDate?: boolean;
+}): Promise<{
+  book: BookRecord.Record;
+  userBook: UserBook;
+  followUp: Promise<FollowUpOutcome>;
+}> {
+  const { coverImage, ...recordUpdates } = updates;
+  const userBook = await getUserBook({ ctx, agent, hiveId });
+
+  let original: { value: BookRecord.Record; cid: string } | null = null;
+  if (userBook) {
+    const local = recordFromUserBook(userBook);
+    original = local
+      ? { value: local, cid: userBook.cid }
+      : await getBookRecord({ agent, uri: userBook.uri });
+    ctx.addWideEventContext({ book_merge_source: local ? "local" : "pds" });
+  }
+
+  let coverSource = coverImage;
+  if (!original && !userBook) {
+    const hiveBook = await ctx.db
+      .selectFrom("hive_book")
+      .selectAll()
+      .where("id", "=", hiveId)
+      .executeTakeFirst();
+    if (hiveBook) {
+      coverSource ??= (hiveBook.cover || hiveBook.thumbnail) ?? undefined;
+      Object.assign(recordUpdates, {
+        title: hiveBook.title,
+        authors: hiveBook.authors,
+        ...recordUpdates,
+      });
+    }
+  }
+
+  const [identifiersRow, hiveBookUri] = await Promise.all([
+    findBookIdentifiersByLookup({ ctx, hiveId }),
+    getCatalogedBookUri(ctx, hiveId),
+  ]);
+  const identifiers = toBookIdentifiersOutput(identifiersRow);
+
+  const build = (originalBook: BookRecord.Record | null) =>
+    buildBookRecord({
+      originalBook,
+      updates: recordUpdates,
+      hiveId,
+      identifiers,
+      hiveBookUri,
+      skipAutoDate,
+    });
+
+  let record = build(original?.value ?? null);
+  const rkey = userBook ? userBook.uri.split("/").at(-1)! : TID.now();
+  let written = await writeBookRecord({
+    agent,
+    rkey,
+    record,
+    swapRecord: original?.cid ?? null,
   });
 
-  type ApplyOut = {
-    results?: Array<{ $type: string; uri?: string; cid?: string }>;
-  };
-  const applyData = response.ok ? (response.data as ApplyOut) : null;
-  const firstResult = applyData?.results?.[0];
-  if (
-    !response.ok ||
-    !applyData?.results ||
-    applyData.results.length === 0 ||
-    !firstResult ||
-    !(
-      firstResult.$type === "com.atproto.repo.applyWrites#updateResult" ||
-      firstResult.$type === "com.atproto.repo.applyWrites#createResult"
-    )
-  ) {
-    throw new Error("Failed to record book");
+  if (!written.ok && written.error === INVALID_SWAP && userBook) {
+    // Another client wrote first. Re-merge once; a second conflict is an error.
+    const fresh = await getBookRecord({ agent, uri: userBook.uri });
+    ctx.addWideEventContext({ book_merge_source: "pds_after_conflict" });
+    if (fresh) {
+      record = build(fresh.value);
+      written = await writeBookRecord({ agent, rkey, record, swapRecord: fresh.cid });
+    }
   }
-  const nextUserBook = {
-    uri: firstResult.uri!,
-    cid: firstResult.cid!,
-    userDid: agent.did,
-    createdAt: record.createdAt,
-    authors: record.authors,
-    title: record.title,
-    indexedAt: new Date().toISOString(),
-    hiveId: record.hiveId as HiveId,
-    status: record.status || null,
-    owned: record.owned ? 1 : 0,
-    startedAt: record.startedAt || null,
-    finishedAt: record.finishedAt || null,
-    review: record.review || null,
-    stars: record.stars || null,
-    bookProgress: record.bookProgress ?? null,
-    previousReads: record.previousReads ?? null,
-  };
 
+  if (!written.ok) {
+    throw new Error(
+      `Failed to record book: ${written.error}${written.message ? ` (${written.message})` : ""}`,
+    );
+  }
+
+  const nextUserBook = userBookFromRecord({
+    uri: written.uri,
+    cid: written.cid,
+    userDid: agent.did,
+    record,
+  });
   await updateUserBook({ ctx, userBook: nextUserBook });
 
-  return { book: record, userBook: nextUserBook };
+  const followUp = completeUserBookRecord({
+    ctx,
+    agent,
+    userBook: nextUserBook,
+    coverImage: coverSource,
+  });
+
+  return { book: record, userBook: nextUserBook, followUp };
 }
 
 /**
@@ -571,6 +548,7 @@ export async function updateBookRecords({
         stars: record.stars || null,
         bookProgress: record.bookProgress ?? null,
         previousReads: record.previousReads ?? null,
+        record,
       },
       originalUpdate: update,
     });

--- a/src/utils/uploadImageBlob.ts
+++ b/src/utils/uploadImageBlob.ts
@@ -6,7 +6,7 @@ export type { BlobRef };
 
 export async function uploadImageBlob(
   image: string | undefined | null,
-  agent: SessionClient,
+  agent: Pick<SessionClient, "post">,
   maxWidth?: number,
 ): Promise<BlobRef | undefined> {
   if (!image) return undefined;

--- a/src/utils/userBookFollowUp.ts
+++ b/src/utils/userBookFollowUp.ts
@@ -25,7 +25,13 @@ const FOLLOW_UP_CONCURRENCY = 2;
 /** Cover fetch (10s) + resize + upload, or enrich (10s) + catalog (10s), then one write. */
 const FOLLOW_UP_DEADLINE_MS = 60_000;
 
-const slots = new Semaphore(FOLLOW_UP_CONCURRENCY, { label: "user_book_follow_up" });
+/** Shed rather than queue without bound; each waiter holds a record. */
+const FOLLOW_UP_MAX_PENDING = 64;
+
+const slots = new Semaphore(FOLLOW_UP_CONCURRENCY, {
+  label: "user_book_follow_up",
+  maxPending: FOLLOW_UP_MAX_PENDING,
+});
 const inFlight = new Map<string, Promise<FollowUpOutcome>>();
 
 export function followUpNeeds(
@@ -94,8 +100,15 @@ export function completeUserBookRecord({
     return "completed";
   };
 
-  const task: Promise<FollowUpOutcome> = slots
-    .run(() => withTimeout(run(), FOLLOW_UP_DEADLINE_MS, `follow-up ${userBook.uri}`))
+  const task: Promise<FollowUpOutcome> = (async () => {
+    // The slot is held until the work really settles, not until the deadline:
+    // nothing in `run` is cancellable, so releasing on timeout would let a new
+    // follow-up start alongside one still fetching and uploading.
+    const release = await slots.acquireSlot();
+    const running = run();
+    void running.then(release, release);
+    return withTimeout(running, FOLLOW_UP_DEADLINE_MS, `follow-up ${userBook.uri}`);
+  })()
     .catch((): FollowUpOutcome => "failed")
     .then((outcome) => {
       userBookFollowUpTotal.inc(LABEL.userBookFollowUp[outcome]);

--- a/src/utils/userBookFollowUp.ts
+++ b/src/utils/userBookFollowUp.ts
@@ -4,14 +4,18 @@
  * BookHive renders neither from the record, but the cover costs three network
  * hops plus a decode and the catalogue link can mean a 20s scrape — nobody
  * clicking a status should wait for that. The patch is CAS'd on the cid the
- * request wrote and dropped on conflict. The request's wide event is long
- * gone by the time this resolves, so the counter is the only signal.
+ * request wrote; on conflict it re-reads the winner and re-applies on top,
+ * because losing that race to the user's own next edit is the *common* case
+ * (a first add followed by a rating click, while the cover is still
+ * uploading) and no later write re-supplies the cover — dropping the patch
+ * lost it for good. The request's wide event is long gone by the time this
+ * resolves, so the counter is the only signal.
  */
 import type { SessionClient } from "../auth/client";
 import type { BookUtilContext } from "../context";
 import { LABEL, userBookFollowUpTotal } from "../metrics";
 import type { BookRecordValue, UserBook } from "../types";
-import { INVALID_SWAP, writeBookRecord } from "./bookRecordWrite";
+import { getBookRecord, INVALID_SWAP, writeBookRecord } from "./bookRecordWrite";
 import { ensureBookCataloged } from "./ensureBookCataloged";
 import { Semaphore, withTimeout } from "./semaphore";
 import { uploadImageBlob } from "./uploadImageBlob";
@@ -24,6 +28,9 @@ const FOLLOW_UP_DEADLINE_MS = 60_000;
 
 /** Shed rather than queue without bound; each waiter holds a record. */
 const FOLLOW_UP_MAX_PENDING = 64;
+
+/** CAS attempts per follow-up. Each retry is one getRecord + one putRecord. */
+const MAX_CAS_ATTEMPTS = 3;
 
 const slots = new Semaphore(FOLLOW_UP_CONCURRENCY, {
   label: "user_book_follow_up",
@@ -49,7 +56,7 @@ export function completeUserBookRecord({
   coverImage,
 }: {
   ctx: BookUtilContext;
-  agent: Pick<SessionClient, "did" | "post">;
+  agent: Pick<SessionClient, "did" | "post" | "get">;
   userBook: UserBook;
   coverImage: string | undefined;
 }): Promise<FollowUpOutcome> {
@@ -73,34 +80,56 @@ export function completeUserBookRecord({
     }
     if (Object.keys(patch).length === 0) return "nothing";
 
-    const patched: BookRecordValue = { ...record, ...patch };
     const rkey = userBook.uri.split("/").at(-1)!;
-    const written = await writeBookRecord({
-      agent,
-      rkey,
-      record: patched,
-      swapRecord: userBook.cid,
-    });
-    if (!written.ok) {
-      if (written.error === INVALID_SWAP) return "conflict";
-      throw new Error(`follow-up write failed: ${written.error} ${written.message ?? ""}`);
+    // The expensive work (blob upload, scrape) is done; only the write is
+    // retried. Start from the snapshot the request wrote; after a lost race,
+    // re-read whatever won and patch on top of that instead.
+    let target = { record, cid: userBook.cid };
+    for (let attempt = 0; attempt < MAX_CAS_ATTEMPTS; attempt++) {
+      // Only patch what the target still lacks — the race winner may have
+      // brought its own catalogue link.
+      const missing: Partial<BookRecordValue> = {};
+      if (patch.cover && !target.record.cover) missing.cover = patch.cover;
+      if (patch.hiveBookUri && !target.record.hiveBookUri) {
+        missing.hiveBookUri = patch.hiveBookUri;
+      }
+      if (Object.keys(missing).length === 0) return "completed";
+
+      const patched: BookRecordValue = { ...target.record, ...missing };
+      const written = await writeBookRecord({
+        agent,
+        rkey,
+        record: patched,
+        swapRecord: target.cid,
+      });
+      if (written.ok) {
+        // Only the fields this task owns, and only while the row is the one we
+        // patched. Replaying the whole row reverted column-only writes made
+        // during the window — `owned` from an upload (guarded on `owned = 0`,
+        // so it never re-fires) and KOSync progress. Those columns aren't in
+        // the record, so the CAS can't protect them.
+        await ctx.db
+          .updateTable("user_book")
+          .set({
+            cid: written.cid,
+            indexedAt: new Date().toISOString(),
+            record: JSON.stringify(patched),
+          })
+          .where("uri", "=", userBook.uri)
+          .where("cid", "=", target.cid)
+          .execute();
+        return "completed";
+      }
+      if (written.error !== INVALID_SWAP) {
+        throw new Error(`follow-up write failed: ${written.error} ${written.message ?? ""}`);
+      }
+      if (attempt === MAX_CAS_ATTEMPTS - 1) break;
+      const fresh = await getBookRecord({ agent, uri: userBook.uri });
+      // Gone from the PDS: the user removed the book while we worked.
+      if (!fresh) return "conflict";
+      target = { record: fresh.value, cid: fresh.cid };
     }
-    // Only the fields this task owns, and only while the row is the one we
-    // patched. Replaying the whole row reverted column-only writes made during
-    // the window — `owned` from an upload (guarded on `owned = 0`, so it never
-    // re-fires) and KOSync progress. Those columns aren't in the record, so
-    // the CAS can't protect them.
-    await ctx.db
-      .updateTable("user_book")
-      .set({
-        cid: written.cid,
-        indexedAt: new Date().toISOString(),
-        record: JSON.stringify(patched),
-      })
-      .where("uri", "=", userBook.uri)
-      .where("cid", "=", userBook.cid)
-      .execute();
-    return "completed";
+    return "conflict";
   };
 
   const task: Promise<FollowUpOutcome> = (async () => {

--- a/src/utils/userBookFollowUp.ts
+++ b/src/utils/userBookFollowUp.ts
@@ -1,0 +1,109 @@
+/**
+ * Patch `cover` and `hiveBookUri` onto a book record after the response.
+ *
+ * Neither is rendered by BookHive (covers come from `hive_book`), but the
+ * cover costs three network hops plus a decode and the catalogue link can
+ * mean a 20s scrape — the user waiting on a status click should pay for
+ * neither. The patch is CAS'd on the cid the request wrote; on conflict it is
+ * dropped, not forced, since the next write to a still-incomplete record
+ * schedules it again. The request's wide event is gone by the time this
+ * resolves, so the counter is the only signal.
+ */
+import type { SessionClient } from "../auth/client";
+import type { BookUtilContext } from "../context";
+import { LABEL, userBookFollowUpTotal } from "../metrics";
+import type { BookRecordValue, UserBook } from "../types";
+import { INVALID_SWAP, writeBookRecord } from "./bookRecordWrite";
+import { ensureBookCataloged } from "./ensureBookCataloged";
+import { Semaphore, withTimeout } from "./semaphore";
+import { uploadImageBlob } from "./uploadImageBlob";
+import { updateUserBook } from "./userBookStore";
+
+export type FollowUpOutcome = "completed" | "nothing" | "conflict" | "failed";
+
+const FOLLOW_UP_CONCURRENCY = 2;
+/** Cover fetch (10s) + resize + upload, or enrich (10s) + catalog (10s), then one write. */
+const FOLLOW_UP_DEADLINE_MS = 60_000;
+
+const slots = new Semaphore(FOLLOW_UP_CONCURRENCY, { label: "user_book_follow_up" });
+const inFlight = new Map<string, Promise<FollowUpOutcome>>();
+
+export function followUpNeeds(
+  record: BookRecordValue,
+  { coverImage, canCatalog }: { coverImage: string | undefined; canCatalog: boolean },
+): { cover: boolean; catalog: boolean } {
+  return {
+    cover: !record.cover && !!coverImage,
+    catalog: !record.hiveBookUri && canCatalog,
+  };
+}
+
+/** Never rejects: request handlers drop it, tests await it. */
+export function completeUserBookRecord({
+  ctx,
+  agent,
+  userBook,
+  coverImage,
+}: {
+  ctx: BookUtilContext;
+  agent: Pick<SessionClient, "did" | "post">;
+  userBook: UserBook;
+  coverImage: string | undefined;
+}): Promise<FollowUpOutcome> {
+  const record = userBook.record;
+  if (!record) return Promise.resolve("nothing");
+  const needs = followUpNeeds(record, { coverImage, canCatalog: !!ctx.serviceAccountAgent });
+  if (!needs.cover && !needs.catalog) return Promise.resolve("nothing");
+
+  const existing = inFlight.get(userBook.uri);
+  if (existing) return existing;
+
+  const run = async (): Promise<FollowUpOutcome> => {
+    const patch: Partial<BookRecordValue> = {};
+    if (needs.cover) {
+      const blob = await uploadImageBlob(coverImage, agent, 800);
+      if (blob) patch.cover = blob as BookRecordValue["cover"];
+    }
+    if (needs.catalog) {
+      const hiveBookUri = await ensureBookCataloged(ctx, userBook.hiveId);
+      if (hiveBookUri) patch.hiveBookUri = hiveBookUri;
+    }
+    if (Object.keys(patch).length === 0) return "nothing";
+
+    const patched: BookRecordValue = { ...record, ...patch };
+    const rkey = userBook.uri.split("/").at(-1)!;
+    const written = await writeBookRecord({
+      agent,
+      rkey,
+      record: patched,
+      swapRecord: userBook.cid,
+    });
+    if (!written.ok) {
+      if (written.error === INVALID_SWAP) return "conflict";
+      throw new Error(`follow-up write failed: ${written.error} ${written.message ?? ""}`);
+    }
+    await updateUserBook({
+      ctx,
+      userBook: {
+        ...userBook,
+        cid: written.cid,
+        indexedAt: new Date().toISOString(),
+        record: patched,
+      },
+    });
+    return "completed";
+  };
+
+  const task: Promise<FollowUpOutcome> = slots
+    .run(() => withTimeout(run(), FOLLOW_UP_DEADLINE_MS, `follow-up ${userBook.uri}`))
+    .catch((): FollowUpOutcome => "failed")
+    .then((outcome) => {
+      userBookFollowUpTotal.inc(LABEL.userBookFollowUp[outcome]);
+      return outcome;
+    })
+    .finally(() => {
+      inFlight.delete(userBook.uri);
+    });
+  inFlight.set(userBook.uri, task);
+  return task;
+}

--- a/src/utils/userBookFollowUp.ts
+++ b/src/utils/userBookFollowUp.ts
@@ -17,7 +17,6 @@ import { INVALID_SWAP, writeBookRecord } from "./bookRecordWrite";
 import { ensureBookCataloged } from "./ensureBookCataloged";
 import { Semaphore, withTimeout } from "./semaphore";
 import { uploadImageBlob } from "./uploadImageBlob";
-import { updateUserBook } from "./userBookStore";
 
 export type FollowUpOutcome = "completed" | "nothing" | "conflict" | "failed";
 
@@ -88,15 +87,21 @@ export function completeUserBookRecord({
       if (written.error === INVALID_SWAP) return "conflict";
       throw new Error(`follow-up write failed: ${written.error} ${written.message ?? ""}`);
     }
-    await updateUserBook({
-      ctx,
-      userBook: {
-        ...userBook,
+    // Only the three fields this task owns, and only if the row is still the
+    // one we patched. Replaying the whole row would revert column-only writes
+    // made during the up-to-60s window — `owned` from a library upload (whose
+    // `WHERE owned = 0` guard means it never re-fires) and KOSync progress.
+    // The CAS is not enough on its own: those columns are not in the record.
+    await ctx.db
+      .updateTable("user_book")
+      .set({
         cid: written.cid,
         indexedAt: new Date().toISOString(),
-        record: patched,
-      },
-    });
+        record: JSON.stringify(patched),
+      })
+      .where("uri", "=", userBook.uri)
+      .where("cid", "=", userBook.cid)
+      .execute();
     return "completed";
   };
 

--- a/src/utils/userBookFollowUp.ts
+++ b/src/utils/userBookFollowUp.ts
@@ -1,13 +1,11 @@
 /**
  * Patch `cover` and `hiveBookUri` onto a book record after the response.
  *
- * Neither is rendered by BookHive (covers come from `hive_book`), but the
- * cover costs three network hops plus a decode and the catalogue link can
- * mean a 20s scrape — the user waiting on a status click should pay for
- * neither. The patch is CAS'd on the cid the request wrote; on conflict it is
- * dropped, not forced, since the next write to a still-incomplete record
- * schedules it again. The request's wide event is gone by the time this
- * resolves, so the counter is the only signal.
+ * BookHive renders neither from the record, but the cover costs three network
+ * hops plus a decode and the catalogue link can mean a 20s scrape — nobody
+ * clicking a status should wait for that. The patch is CAS'd on the cid the
+ * request wrote and dropped on conflict. The request's wide event is long
+ * gone by the time this resolves, so the counter is the only signal.
  */
 import type { SessionClient } from "../auth/client";
 import type { BookUtilContext } from "../context";
@@ -87,11 +85,11 @@ export function completeUserBookRecord({
       if (written.error === INVALID_SWAP) return "conflict";
       throw new Error(`follow-up write failed: ${written.error} ${written.message ?? ""}`);
     }
-    // Only the three fields this task owns, and only if the row is still the
-    // one we patched. Replaying the whole row would revert column-only writes
-    // made during the up-to-60s window — `owned` from a library upload (whose
-    // `WHERE owned = 0` guard means it never re-fires) and KOSync progress.
-    // The CAS is not enough on its own: those columns are not in the record.
+    // Only the fields this task owns, and only while the row is the one we
+    // patched. Replaying the whole row reverted column-only writes made during
+    // the window — `owned` from an upload (guarded on `owned = 0`, so it never
+    // re-fires) and KOSync progress. Those columns aren't in the record, so
+    // the CAS can't protect them.
     await ctx.db
       .updateTable("user_book")
       .set({
@@ -106,9 +104,8 @@ export function completeUserBookRecord({
   };
 
   const task: Promise<FollowUpOutcome> = (async () => {
-    // The slot is held until the work really settles, not until the deadline:
-    // nothing in `run` is cancellable, so releasing on timeout would let a new
-    // follow-up start alongside one still fetching and uploading.
+    // Held until the work settles, not until the deadline: nothing in `run` is
+    // cancellable, so releasing early lets a new follow-up start alongside it.
     const release = await slots.acquireSlot();
     const running = run();
     void running.then(release, release);

--- a/src/utils/userBookStore.ts
+++ b/src/utils/userBookStore.ts
@@ -1,0 +1,124 @@
+/** `user_book` row access, apart from getBook.ts so the follow-up can import it without a cycle. */
+import type { SessionClient } from "../auth/client";
+import type { BookUtilContext } from "../context";
+import { ids } from "../bsky/lexicon";
+import type { BookRecordValue, HiveId, UserBook, UserBookRow } from "../types";
+import { hydrateUserBook, serializeUserBook } from "./bookProgress";
+
+export async function getUserBook({
+  ctx,
+  agent,
+  hiveId,
+}: {
+  ctx: Pick<BookUtilContext, "db">;
+  agent: Pick<SessionClient, "did">;
+  hiveId: HiveId;
+}): Promise<UserBook | null> {
+  const rawUserBook = await ctx.db
+    .selectFrom("user_book")
+    .selectAll()
+    .where("userDid", "=", agent.did)
+    .where("hiveId", "=", hiveId)
+    .executeTakeFirst();
+
+  if (!rawUserBook) {
+    return null;
+  }
+
+  return hydrateUserBook(rawUserBook);
+}
+
+export async function updateUserBook({
+  ctx,
+  userBook,
+}: {
+  ctx: Pick<BookUtilContext, "db">;
+  userBook: UserBook;
+}): Promise<void> {
+  const row: UserBookRow = serializeUserBook(userBook);
+  await ctx.db
+    .insertInto("user_book")
+    .values(row)
+    .onConflict((oc) =>
+      oc.column("uri").doUpdateSet((c) => ({
+        indexedAt: c.ref("excluded.indexedAt"),
+        cid: c.ref("excluded.cid"),
+        authors: c.ref("excluded.authors"),
+        title: c.ref("excluded.title"),
+        hiveId: c.ref("excluded.hiveId"),
+        status: c.ref("excluded.status"),
+        owned: c.ref("excluded.owned"),
+        startedAt: c.ref("excluded.startedAt"),
+        finishedAt: c.ref("excluded.finishedAt"),
+        review: c.ref("excluded.review"),
+        stars: c.ref("excluded.stars"),
+        bookProgress: c.ref("excluded.bookProgress"),
+        previousReads: c.ref("excluded.previousReads"),
+        record: c.ref("excluded.record"),
+      })),
+    )
+    .execute();
+}
+
+/**
+ * The PDS record as far as this row knows; null on a pre-025 row.
+ *
+ * Columns win over the stored record: some local writes are still on their
+ * way to the PDS (KOSync progress via `sync_pending:`, `owned` from a library
+ * upload), and merging against the record alone would revert them on the
+ * user's next click.
+ */
+export function recordFromUserBook(userBook: UserBook): BookRecordValue | null {
+  const record = userBook.record;
+  if (!record) return null;
+  return {
+    ...record,
+    $type: ids.BuzzBookhiveBook,
+    title: userBook.title,
+    authors: userBook.authors,
+    hiveId: userBook.hiveId,
+    createdAt: userBook.createdAt,
+    status: userBook.status ?? undefined,
+    startedAt: userBook.startedAt ?? undefined,
+    finishedAt: userBook.finishedAt ?? undefined,
+    review: userBook.review ?? undefined,
+    stars: userBook.stars ?? undefined,
+    bookProgress: userBook.bookProgress ?? undefined,
+    previousReads: userBook.previousReads ?? undefined,
+    // The merge defaults an unset `owned` to true; a column 0 must not turn
+    // an old record's unset into false.
+    owned: userBook.owned === 1 ? true : record.owned === undefined ? undefined : false,
+  };
+}
+
+export function userBookFromRecord({
+  uri,
+  cid,
+  userDid,
+  record,
+}: {
+  uri: string;
+  cid: string;
+  userDid: string;
+  record: BookRecordValue;
+}): UserBook {
+  return {
+    uri,
+    cid,
+    userDid,
+    createdAt: record.createdAt,
+    authors: record.authors,
+    title: record.title,
+    indexedAt: new Date().toISOString(),
+    hiveId: record.hiveId as HiveId,
+    status: record.status || null,
+    owned: record.owned ? 1 : 0,
+    startedAt: record.startedAt || null,
+    finishedAt: record.finishedAt || null,
+    review: record.review || null,
+    stars: record.stars || null,
+    bookProgress: record.bookProgress ?? null,
+    previousReads: record.previousReads ?? null,
+    record,
+  };
+}

--- a/src/utils/userBookStore.ts
+++ b/src/utils/userBookStore.ts
@@ -61,12 +61,9 @@ export async function updateUserBook({
 }
 
 /**
- * The PDS record as far as this row knows; null on a pre-025 row.
- *
- * Columns win over the stored record: some local writes are still on their
- * way to the PDS (KOSync progress via `sync_pending:`, `owned` from a library
- * upload), and merging against the record alone would revert them on the
- * user's next click.
+ * The PDS record as far as this row knows; null on a pre-025 row. Columns win:
+ * some writes (KOSync progress, `owned` from an upload) reach the row before
+ * the PDS, and merging against the record alone would revert them.
  */
 export function recordFromUserBook(userBook: UserBook): BookRecordValue | null {
   const record = userBook.record;
@@ -85,8 +82,7 @@ export function recordFromUserBook(userBook: UserBook): BookRecordValue | null {
     stars: userBook.stars ?? undefined,
     bookProgress: userBook.bookProgress ?? undefined,
     previousReads: userBook.previousReads ?? undefined,
-    // The merge defaults an unset `owned` to true; a column 0 must not turn
-    // an old record's unset into false.
+    // The merge defaults unset `owned` to true, so a column 0 must not make it false.
     owned: userBook.owned === 1 ? true : record.owned === undefined ? undefined : false,
   };
 }

--- a/src/utils/userBookView.ts
+++ b/src/utils/userBookView.ts
@@ -1,0 +1,44 @@
+/**
+ * The viewer's relationship to one book. Every book-state write returns it
+ * and the read answers with it, so a client can reconcile without a page
+ * re-render. Excludes `userDid` and the raw PDS `record` (blob refs).
+ */
+import type { BookProgress, HiveId, PreviousRead, UserBook } from "../types";
+
+export type UserBookView = {
+  uri: string;
+  cid: string;
+  hiveId: HiveId;
+  title: string;
+  authors: string;
+  status: string | null;
+  owned: boolean;
+  stars: number | null;
+  review: string | null;
+  startedAt: string | null;
+  finishedAt: string | null;
+  bookProgress: BookProgress | null;
+  previousReads: PreviousRead[] | null;
+  createdAt: string;
+  indexedAt: string;
+};
+
+export function toUserBookView(userBook: UserBook): UserBookView {
+  return {
+    uri: userBook.uri,
+    cid: userBook.cid,
+    hiveId: userBook.hiveId,
+    title: userBook.title,
+    authors: userBook.authors,
+    status: userBook.status ?? null,
+    owned: userBook.owned === 1,
+    stars: userBook.stars ?? null,
+    review: userBook.review ?? null,
+    startedAt: userBook.startedAt ?? null,
+    finishedAt: userBook.finishedAt ?? null,
+    bookProgress: userBook.bookProgress ?? null,
+    previousReads: userBook.previousReads ?? null,
+    createdAt: userBook.createdAt,
+    indexedAt: userBook.indexedAt,
+  };
+}


### PR DESCRIPTION
Hiya, not sure if you're open for contrib but I started using BookHive today and was hoping to help out if it was welcome!

## The problem

Marking a book as read was slow and reloaded the whole page.

Behind the status dropdown, one click did four things in a row: read the record back from your PDS (even though we already have it in SQLite), catalogue the book if it wasn't already (inline, with a 20 second ceiling), fetch/resize/upload the cover on a first add, and then actually write the record. After all that it redirected back to a page that re-renders 1,000 reviews.

Two of those steps produce fields BookHive never even shows. Covers and the catalogue link both come from `hive_book`.

## The fix

**One round-trip per write.** We now merge against the local `user_book` row instead of reading the PDS first. A new `user_book.record` column (migration 025) keeps the three fields the table never had (`cover`, `identifiers`, `hiveBookUri`) so the merge doesn't silently strip them. The write is compare-and-swapped on the record's CID, so if another device got there first we re-read once and try again instead of clobbering it. The cover and catalogue link get patched in *after* the response, CAS'd on the CID we just wrote.

**No more reloads.** Status, owned, rating, review, progress, dates and remove on `/books/:id` are now one small client island. Each change shows up immediately, gets sent as JSON to `/api/update-book`, and the server's `UserBookView` swaps in when it lands. If the write fails, the UI snaps back and tells you. The old forms stick around as the pre-hydration paint.

## Numbers

Bench is `main` vs this branch against a fake PDS at 110ms per call (the real p50 to `bsky.social` from my laptop was 113ms), p50 of 30 runs.

| | Before | After |
|---|---|---|
| Change status of a book you have | 224ms, 2 PDS calls | **112ms, 1 call** |
| First add with cover | 259ms, 2 calls, 39ms of image CPU on the event loop | **112ms, 1 call**, cover patched in after |

I also ran it in a real browser against my real account, whose PDS is a sluggish ~470ms away. Every write landed in 190–420ms, the page never navigated, a status click painted in the same frame, the CAS conflict path re-merged correctly, and a forced failure rolled the UI back with an error. Then I deleted the test book.

## Fine print

- If `book_id_map` has no row for a book, the merge now keeps the record's existing `identifiers` instead of dropping them.
- The optimistic merge mirrors ~60 lines of server rules in `applyOptimistic`. If those rules change, the first frame can be briefly wrong until the real answer lands.
- 618 tests pass, 18 of them new. AGENTS.md is updated.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added interactive book controls for status, ownership, ratings, reviews, reading progress, dates, and library removal.
  * Updates now synchronize with confirmed server state and provide loading, error, and rollback feedback.
  * Added activity history and timestamp displays.
  * Preserved functional form controls for no-JavaScript use.
  * Book updates can refresh the displayed information without a page redirect.

* **Bug Fixes**
  * Improved progress validation and handling of failed or conflicting updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->