### PR TITLE
Add Hardcover import

### DIFF
--- a/package.json
+++ b/package.json
@@ -93,9 +93,9 @@
     "vitest": "catalog:"
   },
   "engines": {
-    "bun": ">=1.3.14"
+    "bun": ">=1.4.0"
   },
-  "packageManager": "bun@1.3.14",
+  "packageManager": "bun@1.4.0",
   "catalog": {
     "vite": "npm:@voidzero-dev/vite-plus-core@latest",
     "vitest": "npm:@voidzero-dev/vite-plus-test@latest",

--- a/src/client/components/import/types.ts
+++ b/src/client/components/import/types.ts
@@ -1,4 +1,4 @@
-export type ImportService = "goodreads" | "storygraph";
+export type ImportService = "goodreads" | "storygraph" | "hardcover";
 
 export type ImportStage = "initializing" | "searching" | "uploading" | "complete";
 

--- a/src/metrics.ts
+++ b/src/metrics.ts
@@ -341,12 +341,15 @@ export const LABEL = {
   import: {
     goodreads: labelKey({ source: "goodreads" }),
     storygraph: labelKey({ source: "storygraph" }),
+    hardcover: labelKey({ source: "hardcover" }),
   },
   importOutcome: {
     goodreadsMatched: labelKey({ source: "goodreads", outcome: "matched" }),
     goodreadsUnmatched: labelKey({ source: "goodreads", outcome: "unmatched" }),
     storygraphMatched: labelKey({ source: "storygraph", outcome: "matched" }),
     storygraphUnmatched: labelKey({ source: "storygraph", outcome: "unmatched" }),
+    hardcoverMatched: labelKey({ source: "hardcover", outcome: "matched" }),
+    hardcoverUnmatched: labelKey({ source: "hardcover", outcome: "unmatched" }),
   },
   followSync: {
     full: labelKey({ sync_type: "full" }),

--- a/src/pages/import.tsx
+++ b/src/pages/import.tsx
@@ -33,6 +33,12 @@ export const LibraryImport: FC = () => {
                   <span class="font-medium text-foreground">From StoryGraph</span>
                 </div>
               </label>
+              <label class="flex cursor-pointer">
+                <input type="radio" name="import-service" value="hardcover" class="peer sr-only" />
+                <div class="card flex flex-1 items-center px-4 py-3 shadow-sm min-h-[44px] transition-[box-shadow,background-color] duration-150 peer-checked:shadow-[0_0_0_2px_var(--primary)] peer-checked:bg-primary/5 hover:shadow-md min-w-[140px]">
+                  <span class="font-medium text-foreground">From Hardcover</span>
+                </div>
+              </label>
             </div>
           </div>
 
@@ -64,6 +70,21 @@ export const LibraryImport: FC = () => {
                 User Export
               </a>{" "}
               page and export your library as CSV, then upload it below.
+            </p>
+          </div>
+
+          <div id="hardcover-instructions" class="mb-6 hidden">
+            <p class="text-muted-foreground text-sm">
+              To import your Hardcover library,{" "}
+              <a
+                href="https://hardcover.app/account/exports"
+                class="font-medium text-primary hover:underline"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                export your library from Hardcover
+              </a>
+              , then upload the CSV file below.
             </p>
           </div>
 
@@ -121,17 +142,24 @@ export const LibraryImport: FC = () => {
                 ) as NodeListOf<HTMLInputElement>;
                 const goodreadsInstructions = document.getElementById("goodreads-instructions");
                 const storygraphInstructions = document.getElementById("storygraph-instructions");
+                const hardcoverInstructions = document.getElementById("hardcover-instructions");
 
                 function updateSelection() {
                   const selectedService = document.querySelector(
                     'input[name="import-service"]:checked',
                   ) as HTMLInputElement;
-                  if (selectedService?.value === "storygraph") {
-                    goodreadsInstructions?.classList.add("hidden");
-                    storygraphInstructions?.classList.remove("hidden");
-                  } else {
+                  if (selectedService?.value === "goodreads") {
                     goodreadsInstructions?.classList.remove("hidden");
                     storygraphInstructions?.classList.add("hidden");
+                    hardcoverInstructions?.classList.add("hidden");
+                  } else if (selectedService?.value === "storygraph") {
+                    goodreadsInstructions?.classList.add("hidden");
+                    storygraphInstructions?.classList.remove("hidden");
+                    hardcoverInstructions?.classList.add("hidden");
+                  } else {
+                    goodreadsInstructions?.classList.add("hidden");
+                    storygraphInstructions?.classList.add("hidden");
+                    hardcoverInstructions?.classList.remove("hidden");
                   }
                 }
 
@@ -157,9 +185,11 @@ export const LibraryImport: FC = () => {
                     'input[name="import-service"]:checked',
                   ) as HTMLInputElement;
                   const endpoint =
-                    selectedService?.value === "storygraph"
-                      ? "/import/storygraph"
-                      : "/import/goodreads";
+                    selectedService?.value === "goodreads"
+                      ? "/import/goodreads"
+                      : selectedService?.value === "storygraph"
+                        ? "/import/storygraph"
+                        : "/import/hardcover";
 
                   const form = new FormData();
                   form.append("export", files[0]!);

--- a/src/pages/marketing.tsx
+++ b/src/pages/marketing.tsx
@@ -739,8 +739,9 @@ function ImportSection() {
               Bring your books <span class="text-primary">with you</span>
             </h2>
             <p class="text-muted-foreground mt-5 max-w-lg text-lg">
-              Already have years of reading history on Goodreads or StoryGraph? Don't start from
-              scratch. Export your data from closed platforms and import it straight into BookHive.
+              Already have years of reading history on Goodreads or StoryGraph or Hardcover? Don't
+              start from scratch. Export your data from closed platforms and import it straight into
+              BookHive.
             </p>
             <div class="mt-8 flex flex-wrap gap-3">
               <a href="/import" class="btn btn-primary">
@@ -759,6 +760,10 @@ function ImportSection() {
                   },
                   {
                     name: "StoryGraph",
+                    description: "Bring over your reading history and reviews",
+                  },
+                  {
+                    name: "Hardcover",
                     description: "Bring over your reading history and reviews",
                   },
                 ].map((source) => (

--- a/src/pages/profile.tsx
+++ b/src/pages/profile.tsx
@@ -321,7 +321,7 @@ export const ProfilePage: FC<{
               </h2>
               <p class="empty-description">
                 {isOwnProfile
-                  ? "Search for a book to add your first read, or bring your history over from Goodreads or StoryGraph."
+                  ? "Search for a book to add your first read, or bring your history over from Goodreads or StoryGraph or Hardcover."
                   : `@${handle} hasn't added any books to BookHive yet.`}
               </p>
               {isOwnProfile && (

--- a/src/routes/README.md
+++ b/src/routes/README.md
@@ -8,7 +8,7 @@ Routes are split by domain and mounted with `app.route()`.
 - **`main.tsx`** – Composes context, auth, jsx layout, images, methodOverride, then mounts domain routers and xrpc.
 - **`lib.ts`** – Shared helpers: `searchBooks`, `refetchBooks`, `refetchBuzzes`, `ensureBookIdentifiersCurrent`, `syncFollowsIfNeeded`.
 - **`admin.ts`** – `/admin/export`. Mounted at `/admin` from `app.ts`.
-- **`import.ts`** – `/import/goodreads`, `/import/storygraph`. Mounted at `/import` from `app.ts`.
+- **`import.ts`** – `/import/goodreads`, `/import/storygraph`, `/import/hardcover`. Mounted at `/import` from `app.ts`.
 - **`pages.tsx`** – `/`, `/.well-known/atproto-did`, `/app`, `/privacy-policy`, `/import`, `/genres`, `/genres/:genre`, `/authors/:author`. Mounted at `/` in main.
 - **`profile.tsx`** – `/profile`, `/profile/:handle`, `/profile/:handle/image`, `/refresh-books`. Mounted at `/` in main.
 - **`books.tsx`** – `/:hiveId`, `/:hiveId/comments`, POST `/`, DELETE `/:hiveId`. Mounted at `/books` in main.

--- a/src/routes/import.ts
+++ b/src/routes/import.ts
@@ -1,7 +1,7 @@
 /**
- * Import routes: Goodreads and StoryGraph CSV upload.
+ * Import routes: Goodreads and StoryGraph and Hardcover CSV upload.
  * Spawns a Bun Worker for the heavy processing and relays SSE events.
- * Mount at /import so paths are /import/goodreads, /import/storygraph.
+ * Mount at /import so paths are /import/goodreads, /import/storygraph, /import/hardcover.
  */
 import { zValidator } from "@hono/zod-validator";
 import { Hono } from "hono";
@@ -10,7 +10,7 @@ import { streamSSE } from "hono/streaming";
 import { z } from "zod";
 
 import type { AppEnv } from "../context";
-import type { ImportRequest, ImportWorkerMessage } from "../workers/import/types";
+import { ImportType, type ImportRequest, type ImportWorkerMessage } from "../workers/import/types";
 import { env } from "../env";
 import { activeOperations, importBatchDuration, LABEL } from "../metrics";
 
@@ -41,7 +41,14 @@ async function handleImport(c: Context<AppEnv>, exportFile: File, type: ImportRe
   const csvData = await exportFile.arrayBuffer();
 
   return streamSSE(c, async (stream) => {
-    const importKey = type === "goodreads" ? LABEL.import.goodreads : LABEL.import.storygraph;
+    // default to goodreads
+    const importKey =
+      type === ImportType.storygraph
+        ? LABEL.import.storygraph
+        : type === ImportType.hardcover
+          ? LABEL.import.hardcover
+          : LABEL.import.goodreads;
+
     const end = importBatchDuration.startTimer(importKey);
     activeOperations.inc(LABEL.op.import);
 
@@ -147,11 +154,15 @@ async function handleImport(c: Context<AppEnv>, exportFile: File, type: ImportRe
 const importApp = new Hono<AppEnv>();
 
 importApp.post("/goodreads", zValidator("form", formSchema), async (c) =>
-  handleImport(c, c.req.valid("form").export, "goodreads"),
+  handleImport(c, c.req.valid("form").export, ImportType.goodreads),
 );
 
 importApp.post("/storygraph", zValidator("form", formSchema), async (c) =>
-  handleImport(c, c.req.valid("form").export, "storygraph"),
+  handleImport(c, c.req.valid("form").export, ImportType.storygraph),
+);
+
+importApp.post("/hardcover", zValidator("form", formSchema), async (c) =>
+  handleImport(c, c.req.valid("form").export, ImportType.hardcover),
 );
 
 export default importApp;

--- a/src/routes/pages.tsx
+++ b/src/routes/pages.tsx
@@ -146,7 +146,7 @@ const app = new Hono<AppEnv>()
     }
     return c.render(<LibraryImport />, {
       title: "BookHive | Import",
-      description: "Import your library from Goodreads or StoryGraph to BookHive",
+      description: "Import your library from Goodreads, StoryGraph, or Hardcover to BookHive",
     });
   })
   // Search results page

--- a/src/types.ts
+++ b/src/types.ts
@@ -43,6 +43,14 @@ export type BookIdentifiers = {
   openLibraryId?: string;
 };
 
+export const BookStatus = {
+  finished: "buzz.bookhive.defs#finished",
+  reading: "buzz.bookhive.defs#reading",
+  wantToRead: "buzz.bookhive.defs#wantToRead",
+} as const;
+
+export type BookStatus = (typeof BookStatus)[keyof typeof BookStatus];
+
 export type UserBook = {
   /**
    * Most recent time the book was indexed

--- a/src/utils/csv.test.ts
+++ b/src/utils/csv.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from "bun:test";
-import { getGoodreadsCsvParser, getStorygraphCsvParser } from "./csv";
+import { getGoodreadsCsvParser, getHardcoverCsvParser, getStorygraphCsvParser } from "./csv";
+import { HARDCOVER_CSV } from "../workers/import/import-logic.test";
 
 describe("CSV Parsers", () => {
   describe("Goodreads CSV Parser", () => {
@@ -268,6 +269,224 @@ Test Book,Test Author,"","",ebook,currently-reading,2024/01/01,"","",2,fast,slow
         contentWarningDescription: "Some violence",
         tags: "sci-fi",
         owned: true,
+      });
+    });
+  });
+
+  describe("Hardcover CSV Parser", () => {
+    it("should parse basic Hardcover CSV data correctly", async () => {
+      const parser = getHardcoverCsvParser();
+      const stream = new ReadableStream({
+        start(controller) {
+          controller.enqueue(new TextEncoder().encode(HARDCOVER_CSV));
+          controller.close();
+        },
+      });
+
+      const books = [];
+      const reader = stream.pipeThrough(parser).getReader();
+
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        books.push(value);
+      }
+
+      expect(books).toHaveLength(3);
+
+      // Test first book (want to read)
+      expect(books[0]).toMatchObject({
+        asin: "0374100144",
+        author: "Roberto Bolaño, Natasha Wimmer (Translator)",
+        binding: "",
+        compilation: false,
+        contentWarnings: "",
+        countryCode: "us",
+        dateAdded: new Date("2025-01-15T00:00:00.000Z"),
+        dateFinished: null,
+        dateStarted: null,
+        durationInSeconds: 0,
+        genres: "",
+        hardcoverBookId: "75726",
+        hardcoverEditionId: "25012766",
+        isbn10: "0374100144",
+        isbn13: "9780374100148",
+        languageCode: "en",
+        lists: "",
+        media: "Book",
+        moods: "",
+        owned: false,
+        pages: 898,
+        privacy: "Public",
+        privateNotes: "",
+        publishDate: new Date("2008-11-11T00:00:00.000Z"),
+        publisher: "Farrar, Straus and Giroux",
+        rating: 0,
+        review: "",
+        reviewContainsSpoilers: false,
+        reviewDate: new Date("2025-01-15T13:56:31.000Z"),
+        reviewMediaUrl: "",
+        reviewSlate: "{}",
+        reviewUrl: "",
+        series: "2666 (#1.0)",
+        sponsoredReview: false,
+        status: "buzz.bookhive.defs#wantToRead",
+        title: "2666",
+      });
+
+      expect(books[0]!.dateAdded).toBeInstanceOf(Date);
+      expect(books[0]!.dateAdded?.getFullYear()).toBe(2025);
+
+      // Test second book (read with date finished)
+      expect(books[1]).toMatchObject({
+        asin: "B0036G94XY",
+        author: "William Gibson",
+        binding: "",
+        compilation: false,
+        contentWarnings: "",
+        countryCode: "us",
+        dateAdded: new Date("2025-01-10T00:00:00.000Z"),
+        dateFinished: new Date("2025-01-23T00:00:00.000Z"),
+        dateStarted: new Date("2025-01-01T00:00:00.000Z"),
+        durationInSeconds: 25686,
+        genres: "",
+        hardcoverBookId: "2440",
+        hardcoverEditionId: "31159321",
+        isbn10: "",
+        isbn13: "",
+        languageCode: "en",
+        lists: "Owned, Shelved By Genre Reading List (#19)",
+        media: "Audio",
+        moods: "",
+        owned: true,
+        pages: 191,
+        privacy: "Public",
+        privateNotes: "",
+        publishDate: new Date("1986-04-01T00:00:00.000Z"),
+        publisher: "Audible Frontiers",
+        rating: 9,
+        review: "",
+        reviewContainsSpoilers: false,
+        reviewDate: new Date("2025-01-10T17:21:40.000Z"),
+        reviewMediaUrl: "",
+        reviewSlate: "{}",
+        reviewUrl: "",
+        series: "Sprawl (#0.0)",
+        sponsoredReview: false,
+        status: "buzz.bookhive.defs#finished",
+        tags: "",
+        title: "Burning Chrome",
+      });
+
+      expect(books[1]!.dateFinished).toBeInstanceOf(Date);
+      expect(books[1]!.dateFinished?.getFullYear()).toBe(2025);
+
+      // Test third book (currently-read)
+      expect(books[2]).toMatchObject({
+        asin: "",
+        author: "Dan Simmons",
+        binding: "",
+        compilation: false,
+        contentWarnings: "",
+        countryCode: "us",
+        dateAdded: new Date("2025-01-15T00:00:00.000Z"),
+        dateFinished: null,
+        dateStarted: new Date("2025-01-25T00:00:00.000Z"),
+        durationInSeconds: 0,
+        genres: "",
+        hardcoverBookId: "427460",
+        hardcoverEditionId: "30428122",
+        isbn10: "0385263481",
+        isbn13: "9780385263481",
+        languageCode: "en",
+        lists: "Owned",
+        media: "Book",
+        moods: "",
+        owned: true,
+        pages: 492,
+        privacy: "Public",
+        privateNotes: "",
+        publishDate: new Date("1989-05-26T00:00:00.000Z"),
+        publisher: "Crown",
+        rating: 0,
+        review: "",
+        reviewContainsSpoilers: false,
+        reviewDate: new Date("2025-01-15T13:56:57.000Z"),
+        reviewMediaUrl: "",
+        reviewSlate: "{}",
+        reviewUrl: "",
+        series: "Hyperion Cantos (#1.0)",
+        sponsoredReview: false,
+        status: "buzz.bookhive.defs#reading",
+        tags: "",
+        title: "Hyperion",
+      });
+    });
+
+    it("should handle empty values and different read statuses correctly", async () => {
+      const csvData = `
+Title,Author,Series,Status,Privacy,Hardcover Book ID,Hardcover Edition ID,ISBN 10,ISBN 13,ASIN,Media,Country Code,Language Code,Binding,Pages,Duration in Seconds,Publish Date,Publisher,Genres,Moods,Tags,Content Warnings,Lists,Date Added,Date Started,Date Finished,Rating,Review,Review Contains Spoilers,Sponsored Review,Review Date,Review URL,Review Media URL,Private Notes,Owned,Compilation,Review Slate
+Mistborn: The Final Empire,Brandon Sanderson,The Mistborn Saga: The Original Trilogy (#1.0),Stopped,Public,369692,30432878,0765377136,9780765377135,,Book,us,en,,541,,2006-07-17,Tor Teen,,,,,Owned,2025-01-15,2024-08-01,"",1.5,,false,false,2025-01-15T13:57:07Z,,,,true,No,{}
+`;
+
+      const parser = getHardcoverCsvParser();
+      const stream = new ReadableStream({
+        start(controller) {
+          controller.enqueue(new TextEncoder().encode(csvData));
+          controller.close();
+        },
+      });
+
+      const books = [];
+      const reader = stream.pipeThrough(parser).getReader();
+
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        books.push(value);
+      }
+
+      expect(books).toHaveLength(1);
+
+      // Test book with various filled fields
+      expect(books[0]).toMatchObject({
+        asin: "",
+        author: "Brandon Sanderson",
+        binding: "",
+        compilation: false,
+        contentWarnings: "",
+        countryCode: "us",
+        dateAdded: new Date("2025-01-15T00:00:00.000Z"),
+        dateFinished: null,
+        dateStarted: new Date("2024-08-01T00:00:00.000Z"),
+        durationInSeconds: 0,
+        genres: "",
+        hardcoverBookId: "369692",
+        hardcoverEditionId: "30432878",
+        isbn10: "0765377136",
+        isbn13: "9780765377135",
+        languageCode: "en",
+        lists: "Owned",
+        media: "Book",
+        moods: "",
+        owned: true,
+        pages: 541,
+        privacy: "Public",
+        privateNotes: "",
+        publishDate: new Date("2006-07-17T00:00:00.000Z"),
+        publisher: "Tor Teen",
+        rating: 3,
+        review: "",
+        reviewContainsSpoilers: false,
+        reviewDate: new Date("2025-01-15T13:57:07.000Z"),
+        reviewMediaUrl: "",
+        reviewSlate: "{}",
+        reviewUrl: "",
+        series: "The Mistborn Saga: The Original Trilogy (#1.0)",
+        sponsoredReview: false,
+        status: "buzz.bookhive.defs#wantToRead",
+        tags: "",
+        title: "Mistborn: The Final Empire",
       });
     });
   });

--- a/src/utils/csv.test.ts
+++ b/src/utils/csv.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "bun:test";
 import { getGoodreadsCsvParser, getHardcoverCsvParser, getStorygraphCsvParser } from "./csv";
-import { HARDCOVER_CSV } from "../workers/import/import-logic.test";
+import { HARDCOVER_CSV } from "../workers/import/__fixtures__/hardcover-csv";
 
 describe("CSV Parsers", () => {
   describe("Goodreads CSV Parser", () => {

--- a/src/utils/csv.test.ts
+++ b/src/utils/csv.test.ts
@@ -275,10 +275,11 @@ Test Book,Test Author,"","",ebook,currently-reading,2024/01/01,"","",2,fast,slow
 
   describe("Hardcover CSV Parser", () => {
     it("should parse basic Hardcover CSV data correctly", async () => {
+      const csvData = HARDCOVER_CSV;
       const parser = getHardcoverCsvParser();
       const stream = new ReadableStream({
         start(controller) {
-          controller.enqueue(new TextEncoder().encode(HARDCOVER_CSV));
+          controller.enqueue(new TextEncoder().encode(csvData));
           controller.close();
         },
       });

--- a/src/utils/csv.ts
+++ b/src/utils/csv.ts
@@ -304,3 +304,152 @@ export function getGoodreadsCsvParser() {
     },
   });
 }
+
+export interface HardcoverBook {
+  title: string;
+  author: string;
+  series: string;
+  status: string;
+  privacy: string;
+  hardcoverBookId: string;
+  hardcoverEditionId: string;
+  isbn10: string;
+  isbn13: string;
+  asin: string;
+  media: string;
+  countryCode: string;
+  languageCode: string;
+  binding: string;
+  pages: number;
+  durationInSeconds: number;
+  publishDate: Date | null;
+  publisher: string;
+  genres: string;
+  moods: string;
+  tags: string;
+  contentWarnings: string;
+  lists: string;
+  dateAdded: Date | null;
+  dateStarted: Date | null;
+  dateFinished: Date | null;
+  rating: number;
+  review: string;
+  reviewContainsSpoilers: boolean;
+  sponsoredReview: boolean;
+  reviewDate: Date | null;
+  reviewUrl: string;
+  reviewMediaUrl: string;
+  privateNotes: string;
+  owned: boolean;
+  compilation: boolean;
+  reviewSlate: string;
+}
+
+function get(record: Record<string, string>, key: string): string {
+  return record[key] || "";
+}
+
+function parseDate(date: string): Date | null {
+  const newDate = new Date(date);
+  if (isNaN(newDate.getTime())) return null;
+  return newDate;
+}
+
+function parseBoolean(input: string): boolean {
+  return input.toLowerCase() === "true";
+}
+
+export function parseHardcoverRecord(record: Record<string, string>): HardcoverBook {
+  return {
+    title: get(record, "Title"),
+    author: get(record, "Author"),
+    series: get(record, "Series"),
+    status: get(record, "Status"),
+    privacy: get(record, "Privacy"),
+    hardcoverBookId: get(record, "Hardcover Book ID"),
+    hardcoverEditionId: get(record, "Hardcover Edition ID"),
+    isbn10: get(record, "ISBN 10"),
+    isbn13: get(record, "ISBN 13"),
+    asin: get(record, "ASIN"),
+    media: get(record, "Media"),
+    countryCode: get(record, "Country Code"),
+    languageCode: get(record, "Language Code"),
+    binding: get(record, "Binding"),
+    pages: parseInt(get(record, "Pages")) || 0,
+    durationInSeconds: parseInt(get(record, "Duration in Seconds")) || 0,
+    publishDate: parseDate(get(record, "Publish Date")),
+    publisher: get(record, "Publisher"),
+    genres: get(record, "Genres"),
+    moods: get(record, "Moods"),
+    tags: get(record, "Tags"),
+    contentWarnings: get(record, "Content Warnings"),
+    lists: get(record, "Lists"),
+    dateAdded: parseDate(get(record, "Date Added")),
+    dateStarted: parseDate(get(record, "Date Started")),
+    dateFinished: parseDate(get(record, "Date Finished")),
+    rating: parseInt(`${parseFloat(get(record, "Rating")) * 2}`) || 0,
+    review: get(record, "Review"),
+    reviewContainsSpoilers: parseBoolean(get(record, "Review Contains Spoilers")),
+    sponsoredReview: parseBoolean(get(record, "Sponsored Review")),
+    reviewDate: parseDate(get(record, "Review Date")),
+    reviewUrl: get(record, "Review Url"),
+    reviewMediaUrl: get(record, "Review Media Url"),
+    privateNotes: get(record, "Private Notes"),
+    owned: parseBoolean(get(record, "Owned")),
+    compilation: get(record, "Compilation").toLowerCase() === "yes",
+    reviewSlate: get(record, "Review Slate"),
+  };
+}
+
+export function getHardcoverCsvParser() {
+  const parser = parse({
+    columns: true,
+    skip_records_with_error: true,
+    relax_column_count: true,
+    relax_quotes: true,
+    cast: (value?: string): string => {
+      if (!value) return "";
+      if (value.startsWith('"') && value.endsWith('"')) {
+        value = value.slice(1, -1);
+      }
+      return value;
+    },
+  });
+
+  return new TransformStream<Uint8Array, HardcoverBook>({
+    transform(chunk, controller) {
+      try {
+        parser.write(chunk);
+
+        // Process any records that are ready
+        let record: Record<string, string> | undefined;
+        while ((record = parser.read())) {
+          if (record && "Title" in record && "Author" in record) {
+            controller.enqueue(parseHardcoverRecord(record));
+          } else {
+            console.warn("Skipping invalid Hardcover record:", record);
+          }
+        }
+      } catch (error) {
+        console.warn("Error processing CSV chunk:", error);
+      }
+    },
+    flush(controller) {
+      try {
+        parser.end();
+
+        // Get any remaining records
+        let record: any;
+        while ((record = parser.read())) {
+          if (record && "Title" in record && "Author" in record) {
+            controller.enqueue(parseHardcoverRecord(record));
+          } else {
+            console.warn("Skipping invalid Hardcover record during flush:", record);
+          }
+        }
+      } catch (error) {
+        console.warn("Error during CSV parser flush:", error);
+      }
+    },
+  });
+}

--- a/src/utils/csv.ts
+++ b/src/utils/csv.ts
@@ -1,4 +1,5 @@
 import { parse } from "csv-parse";
+import { BookStatus } from "../types";
 
 export interface GoodreadsBook {
   bookId: string;
@@ -309,7 +310,7 @@ export interface HardcoverBook {
   title: string;
   author: string;
   series: string;
-  status: string;
+  status: BookStatus;
   privacy: string;
   hardcoverBookId: string;
   hardcoverEditionId: string;
@@ -359,17 +360,35 @@ function parseBoolean(input: string): boolean {
   return input.toLowerCase() === "true";
 }
 
+function parseStatus(status: string, dateFinished: Date | null): BookStatus {
+  switch (status.toLowerCase()) {
+    case "read":
+    case BookStatus.finished:
+      return BookStatus.finished;
+    case "currently reading":
+    case BookStatus.reading:
+      return BookStatus.reading;
+    case "want to read":
+    case BookStatus.wantToRead:
+      return BookStatus.wantToRead;
+    case "stopped":
+    default:
+      return dateFinished ? BookStatus.finished : BookStatus.wantToRead;
+  }
+}
+
 export function parseHardcoverRecord(record: Record<string, string>): HardcoverBook {
+  const dateFinished = parseDate(get(record, "Date Finished"));
   return {
     title: get(record, "Title"),
     author: get(record, "Author"),
     series: get(record, "Series"),
-    status: get(record, "Status"),
+    status: parseStatus(get(record, "Status"), dateFinished),
     privacy: get(record, "Privacy"),
     hardcoverBookId: get(record, "Hardcover Book ID"),
     hardcoverEditionId: get(record, "Hardcover Edition ID"),
-    isbn10: get(record, "ISBN 10"),
-    isbn13: get(record, "ISBN 13"),
+    isbn10: get(record, "ISBN 10").replace(/[-\s]/g, ""),
+    isbn13: get(record, "ISBN 13").replace(/[-\s]/g, ""),
     asin: get(record, "ASIN"),
     media: get(record, "Media"),
     countryCode: get(record, "Country Code"),
@@ -386,14 +405,14 @@ export function parseHardcoverRecord(record: Record<string, string>): HardcoverB
     lists: get(record, "Lists"),
     dateAdded: parseDate(get(record, "Date Added")),
     dateStarted: parseDate(get(record, "Date Started")),
-    dateFinished: parseDate(get(record, "Date Finished")),
+    dateFinished,
     rating: parseInt(`${parseFloat(get(record, "Rating")) * 2}`) || 0,
     review: get(record, "Review"),
     reviewContainsSpoilers: parseBoolean(get(record, "Review Contains Spoilers")),
     sponsoredReview: parseBoolean(get(record, "Sponsored Review")),
     reviewDate: parseDate(get(record, "Review Date")),
-    reviewUrl: get(record, "Review Url"),
-    reviewMediaUrl: get(record, "Review Media Url"),
+    reviewUrl: get(record, "Review URL"),
+    reviewMediaUrl: get(record, "Review Media URL"),
     privateNotes: get(record, "Private Notes"),
     owned: parseBoolean(get(record, "Owned")),
     compilation: get(record, "Compilation").toLowerCase() === "yes",
@@ -404,9 +423,13 @@ export function parseHardcoverRecord(record: Record<string, string>): HardcoverB
 export function getHardcoverCsvParser() {
   const parser = parse({
     columns: true,
-    skip_records_with_error: true,
     relax_column_count: true,
     relax_quotes: true,
+    skip_empty_lines: true,
+    skip_records_with_error: true,
+    trim: true,
+    // all coercion and parsing logic is handled in parseHardcoverRecord,
+    // this is merely to ensure everything is a string without wrapping quotes
     cast: (value?: string): string => {
       if (!value) return "";
       if (value.startsWith('"') && value.endsWith('"')) {
@@ -424,11 +447,14 @@ export function getHardcoverCsvParser() {
         // Process any records that are ready
         let record: Record<string, string> | undefined;
         while ((record = parser.read())) {
-          if (record && "Title" in record && "Author" in record) {
-            controller.enqueue(parseHardcoverRecord(record));
-          } else {
-            console.warn("Skipping invalid Hardcover record:", record);
+          if (record) {
+            const parsedRecord = parseHardcoverRecord(record);
+            if (parsedRecord.title !== "" && parsedRecord.author !== "") {
+              controller.enqueue(parsedRecord);
+              continue;
+            }
           }
+          console.warn("Skipping invalid Hardcover record:", record);
         }
       } catch (error) {
         console.warn("Error processing CSV chunk:", error);

--- a/src/utils/importBook.ts
+++ b/src/utils/importBook.ts
@@ -32,21 +32,6 @@ export function mapStorygraphStatus(book: Pick<StorygraphBook, "readStatus">): B
   }
 }
 
-export function mapHardcoverStatus(
-  book: Pick<HardcoverBook, "dateFinished" | "status">,
-): BookStatus {
-  switch (book.status.toLowerCase()) {
-    case "read":
-      return BookStatus.finished;
-    case "currently reading":
-      return BookStatus.reading;
-    case "want to read":
-      return BookStatus.wantToRead;
-    default:
-      return book.dateFinished ? BookStatus.finished : BookStatus.wantToRead;
-  }
-}
-
 export function normalizeGoodreadsRating(myRating: number): number | undefined {
   return myRating ? myRating * 2 : undefined;
 }
@@ -110,22 +95,17 @@ export function mergeStorygraphIdentifiers(params: {
 }
 
 export function mergeHardcoverIdentifiers(params: {
-  isbn10: string;
-  isbn13: string;
+  book: HardcoverBook;
   existingIdentifiers: BookIdentifiers;
   hiveBookId: string;
 }): { identifiers: BookIdentifiers; changed: boolean } {
-  const { isbn10, isbn13, existingIdentifiers, hiveBookId } = params;
-  if (!isbn10 || !isbn13) {
-    return { identifiers: existingIdentifiers, changed: false };
-  }
-  const cleanIsbn10 = isbn10.replace(/[-\s]/g, "");
-  const cleanIsbn13 = isbn13.replace(/[-\s]/g, "");
+  const { book, existingIdentifiers, hiveBookId } = params;
+  const { isbn10, isbn13 } = book;
   const newIdentifiers: BookIdentifiers = {
     ...existingIdentifiers,
     hiveId: hiveBookId,
-    ...(cleanIsbn10.length === 10 ? { isbn10: cleanIsbn10 } : {}),
-    ...(cleanIsbn13.length === 13 ? { isbn13: cleanIsbn13 } : {}),
+    ...(isbn10.length === 10 ? { isbn10 } : {}),
+    ...(isbn13.length === 13 ? { isbn13 } : {}),
   };
   const changed =
     newIdentifiers.isbn10 !== existingIdentifiers.isbn10 ||
@@ -186,15 +166,16 @@ export function buildHardcoverBookRecord(params: {
   existingHiveIds: Set<string>;
 }) {
   const { book, hiveBook, existingHiveIds } = params;
-  const status = mapHardcoverStatus(book);
   return {
     title: hiveBook.title,
     authors: book.author,
-    status,
+    status: book.status,
     hiveId: hiveBook.id,
     coverImage: hiveBook.cover ?? undefined,
     finishedAt:
-      status === BookStatus.finished ? (book.dateFinished?.toISOString() ?? undefined) : undefined,
+      book.status === BookStatus.finished
+        ? (book.dateFinished?.toISOString() ?? undefined)
+        : undefined,
     stars: book.rating,
     review: book.review,
     owned: book.owned,

--- a/src/utils/importBook.ts
+++ b/src/utils/importBook.ts
@@ -1,5 +1,5 @@
-import type { BookIdentifiers } from "../types";
-import type { GoodreadsBook, StorygraphBook } from "./csv";
+import { type BookIdentifiers, BookStatus } from "../types";
+import type { GoodreadsBook, StorygraphBook, HardcoverBook } from "./csv";
 import { normalizeGoodreadsId } from "./bookIdentifiers";
 
 export function normalizeStr(s: string): string {
@@ -8,27 +8,42 @@ export function normalizeStr(s: string): string {
 
 export function mapGoodreadsStatus(
   book: Pick<GoodreadsBook, "dateRead" | "exclusiveShelf">,
-): string {
+): BookStatus {
   switch (book.exclusiveShelf?.toLowerCase()) {
     case "read":
-      return "buzz.bookhive.defs#finished";
+      return BookStatus.finished;
     case "currently-reading":
-      return "buzz.bookhive.defs#reading";
+      return BookStatus.reading;
     case "to-read":
-      return "buzz.bookhive.defs#wantToRead";
+      return BookStatus.wantToRead;
     default:
-      return book.dateRead ? "buzz.bookhive.defs#finished" : "buzz.bookhive.defs#wantToRead";
+      return book.dateRead ? BookStatus.finished : BookStatus.wantToRead;
   }
 }
 
-export function mapStorygraphStatus(book: Pick<StorygraphBook, "readStatus">): string {
+export function mapStorygraphStatus(book: Pick<StorygraphBook, "readStatus">): BookStatus {
   switch (book.readStatus?.toLowerCase()) {
     case "read":
-      return "buzz.bookhive.defs#finished";
+      return BookStatus.finished;
     case "currently-reading":
-      return "buzz.bookhive.defs#reading";
+      return BookStatus.reading;
     default:
-      return "buzz.bookhive.defs#wantToRead";
+      return BookStatus.wantToRead;
+  }
+}
+
+export function mapHardcoverStatus(
+  book: Pick<HardcoverBook, "dateFinished" | "status">,
+): BookStatus {
+  switch (book.status.toLowerCase()) {
+    case "read":
+      return BookStatus.finished;
+    case "currently reading":
+      return BookStatus.reading;
+    case "want to read":
+      return BookStatus.wantToRead;
+    default:
+      return book.dateFinished ? BookStatus.finished : BookStatus.wantToRead;
   }
 }
 
@@ -94,6 +109,31 @@ export function mergeStorygraphIdentifiers(params: {
   return { identifiers: newIdentifiers, changed };
 }
 
+export function mergeHardcoverIdentifiers(params: {
+  isbn10: string;
+  isbn13: string;
+  existingIdentifiers: BookIdentifiers;
+  hiveBookId: string;
+}): { identifiers: BookIdentifiers; changed: boolean } {
+  const { isbn10, isbn13, existingIdentifiers, hiveBookId } = params;
+  if (!isbn10 || !isbn13) {
+    return { identifiers: existingIdentifiers, changed: false };
+  }
+  const cleanIsbn10 = isbn10.replace(/[-\s]/g, "");
+  const cleanIsbn13 = isbn13.replace(/[-\s]/g, "");
+  const newIdentifiers: BookIdentifiers = {
+    ...existingIdentifiers,
+    hiveId: hiveBookId,
+    ...(cleanIsbn10.length === 10 ? { isbn10: cleanIsbn10 } : {}),
+    ...(cleanIsbn13.length === 13 ? { isbn13: cleanIsbn13 } : {}),
+  };
+  const changed =
+    newIdentifiers.isbn10 !== existingIdentifiers.isbn10 ||
+    newIdentifiers.isbn13 !== existingIdentifiers.isbn13 ||
+    !existingIdentifiers.hiveId;
+  return { identifiers: newIdentifiers, changed };
+}
+
 type HiveBookInfo = { id: string; title: string; cover: string | null };
 
 export function buildGoodreadsBookRecord(params: {
@@ -110,9 +150,7 @@ export function buildGoodreadsBookRecord(params: {
     hiveId: hiveBook.id,
     coverImage: hiveBook.cover ?? undefined,
     finishedAt:
-      status === "buzz.bookhive.defs#finished"
-        ? (book.dateRead?.toISOString() ?? undefined)
-        : undefined,
+      status === BookStatus.finished ? (book.dateRead?.toISOString() ?? undefined) : undefined,
     stars: normalizeGoodreadsRating(book.myRating),
     review: book.myReview || undefined,
     owned: book.ownedCopies > 0 ? true : undefined,
@@ -134,12 +172,32 @@ export function buildStorygraphBookRecord(params: {
     hiveId: hiveBook.id,
     coverImage: hiveBook.cover ?? undefined,
     finishedAt:
-      status === "buzz.bookhive.defs#finished"
-        ? (book.lastDateRead?.toISOString() ?? undefined)
-        : undefined,
+      status === BookStatus.finished ? (book.lastDateRead?.toISOString() ?? undefined) : undefined,
     stars: normalizeStorygraphRating(book.starRating),
     review: book.review || undefined,
     owned: book.owned ? true : undefined,
+    alreadyExists: existingHiveIds.has(hiveBook.id),
+  };
+}
+
+export function buildHardcoverBookRecord(params: {
+  book: HardcoverBook;
+  hiveBook: HiveBookInfo;
+  existingHiveIds: Set<string>;
+}) {
+  const { book, hiveBook, existingHiveIds } = params;
+  const status = mapHardcoverStatus(book);
+  return {
+    title: hiveBook.title,
+    authors: book.author,
+    status,
+    hiveId: hiveBook.id,
+    coverImage: hiveBook.cover ?? undefined,
+    finishedAt:
+      status === BookStatus.finished ? (book.dateFinished?.toISOString() ?? undefined) : undefined,
+    stars: book.rating,
+    review: book.review,
+    owned: book.owned,
     alreadyExists: existingHiveIds.has(hiveBook.id),
   };
 }

--- a/src/workers/import/__fixtures__/hardcover-csv.ts
+++ b/src/workers/import/__fixtures__/hardcover-csv.ts
@@ -1,0 +1,13 @@
+/**
+ * Hardcover export sample, shared by the import-worker suite and the CSV
+ * parser suite. It lives outside both because a `.test.ts` cannot export a
+ * fixture safely: `import-logic.test.ts` has a top-level `await import(...)`
+ * (it mocks before importing), so a test file importing from it starts running
+ * its own tests while that module is still suspended, and the constant is
+ * still in its temporal dead zone — "Cannot access 'HARDCOVER_CSV' before
+ * initialization", but only under `bun test --parallel`.
+ */
+export const HARDCOVER_CSV = `Title,Author,Series,Status,Privacy,Hardcover Book ID,Hardcover Edition ID,ISBN 10,ISBN 13,ASIN,Media,Country Code,Language Code,Binding,Pages,Duration in Seconds,Publish Date,Publisher,Genres,Moods,Tags,Content Warnings,Lists,Date Added,Date Started,Date Finished,Rating,Review,Review Contains Spoilers,Sponsored Review,Review Date,Review URL,Review Media URL,Private Notes,Owned,Compilation,Review Slate
+2666,"Roberto Bolaño, Natasha Wimmer (Translator)",2666 (#1.0),Want to Read,Public,75726,25012766,0374100144,9780374100148,0374100144,Book,us,en,,898,,2008-11-11,"Farrar, Straus and Giroux",,,,,"",2025-01-15,"","",,,false,false,2025-01-15T13:56:31Z,,,,false,No,{}
+Burning Chrome,William Gibson,Sprawl (#0.0),Read,Public,2440,31159321,,,B0036G94XY,Audio,us,en,,191,25686,1986-04-01,Audible Frontiers,,,,,"Owned, Shelved By Genre Reading List (#19)",2025-01-10,2025-01-01,2025-01-23,4.5,,false,false,2025-01-10T17:21:40Z,,,,true,No,{}
+Hyperion,Dan Simmons,Hyperion Cantos (#1.0),Currently Reading,Public,427460,30428122,0385263481,9780385263481,,Book,us,en,,492,,1989-05-26,Crown,,,,,Owned,2025-01-15,2025-01-25,,,,false,false,2025-01-15T13:56:57Z,,,"",true,No,{}`;

--- a/src/workers/import/import-logic.test.ts
+++ b/src/workers/import/import-logic.test.ts
@@ -5,7 +5,6 @@ import { wrapBunSqliteForKysely } from "../../bun-sqlite-kysely";
 import { migrateToLatest, type DatabaseSchema } from "../../db";
 import type { ImportContext } from "./types";
 import type { SessionClient } from "../../auth/client";
-import { processHardcoverImport } from "./logic";
 
 // Mock getUserRepoRecords to avoid needing valid CAR data from a real PDS
 const mockGetUserRepoRecords = mock(async () => ({
@@ -33,7 +32,8 @@ void mock.module("../../routes/lib", () => ({
 }));
 
 // Import after mocking
-const { processGoodreadsImport, processStorygraphImport } = await import("./logic");
+const { processGoodreadsImport, processStorygraphImport, processHardcoverImport } =
+  await import("./logic");
 
 // --- Test helpers ---
 
@@ -280,7 +280,7 @@ Burning Chrome,William Gibson,Sprawl (#0.0),Read,Public,2440,31159321,,,B0036G94
 Hyperion,Dan Simmons,Hyperion Cantos (#1.0),Currently Reading,Public,427460,30428122,0385263481,9780385263481,,Book,us,en,,492,,1989-05-26,Crown,,,,,Owned,2025-01-15,2025-01-25,,,,false,false,2025-01-15T13:56:57Z,,,"",true,No,{}`;
 
 describe("processHardcoverImport", () => {
-  it("emits correct SSE lifecycle events for StoryGraph CSV", async () => {
+  it("emits correct SSE lifecycle events for Hardcover CSV", async () => {
     const { db, sqlite } = await createTestDb();
     seedHiveBook(
       sqlite,

--- a/src/workers/import/import-logic.test.ts
+++ b/src/workers/import/import-logic.test.ts
@@ -5,6 +5,7 @@ import { wrapBunSqliteForKysely } from "../../bun-sqlite-kysely";
 import { migrateToLatest, type DatabaseSchema } from "../../db";
 import type { ImportContext } from "./types";
 import type { SessionClient } from "../../auth/client";
+import { HARDCOVER_CSV } from "./__fixtures__/hardcover-csv";
 
 // Mock getUserRepoRecords to avoid needing valid CAR data from a real PDS
 const mockGetUserRepoRecords = mock(async () => ({
@@ -274,21 +275,10 @@ describe("processStorygraphImport", () => {
   });
 });
 
-export const HARDCOVER_CSV = `Title,Author,Series,Status,Privacy,Hardcover Book ID,Hardcover Edition ID,ISBN 10,ISBN 13,ASIN,Media,Country Code,Language Code,Binding,Pages,Duration in Seconds,Publish Date,Publisher,Genres,Moods,Tags,Content Warnings,Lists,Date Added,Date Started,Date Finished,Rating,Review,Review Contains Spoilers,Sponsored Review,Review Date,Review URL,Review Media URL,Private Notes,Owned,Compilation,Review Slate
-2666,"Roberto Bolaño, Natasha Wimmer (Translator)",2666 (#1.0),Want to Read,Public,75726,25012766,0374100144,9780374100148,0374100144,Book,us,en,,898,,2008-11-11,"Farrar, Straus and Giroux",,,,,"",2025-01-15,"","",,,false,false,2025-01-15T13:56:31Z,,,,false,No,{}
-Burning Chrome,William Gibson,Sprawl (#0.0),Read,Public,2440,31159321,,,B0036G94XY,Audio,us,en,,191,25686,1986-04-01,Audible Frontiers,,,,,"Owned, Shelved By Genre Reading List (#19)",2025-01-10,2025-01-01,2025-01-23,4.5,,false,false,2025-01-10T17:21:40Z,,,,true,No,{}
-Hyperion,Dan Simmons,Hyperion Cantos (#1.0),Currently Reading,Public,427460,30428122,0385263481,9780385263481,,Book,us,en,,492,,1989-05-26,Crown,,,,,Owned,2025-01-15,2025-01-25,,,,false,false,2025-01-15T13:56:57Z,,,"",true,No,{}`;
-
 describe("processHardcoverImport", () => {
   it("emits correct SSE lifecycle events for Hardcover CSV", async () => {
     const { db, sqlite } = await createTestDb();
-    seedHiveBook(
-      sqlite,
-      "bk_omw",
-      "Hyperion",
-      "Dan Simmons",
-      "https://covers.example/omw.jpg",
-    );
+    seedHiveBook(sqlite, "bk_omw", "Hyperion", "Dan Simmons", "https://covers.example/omw.jpg");
 
     const ctx = createMockCtx(db);
     const agent = createMockAgent();
@@ -311,20 +301,23 @@ describe("processHardcoverImport", () => {
     expect(complete.stageProgress.current).toBe(1);
     expect(complete.stageProgress.total).toBe(3);
     expect(complete.failedBooks).toHaveLength(2);
-    expect(complete.failedBookDetails).toMatchObject([{
-      title: "2666",
-      author: "Roberto Bolaño, Natasha Wimmer (Translator)",
-      isbn10: "0374100144",
-      isbn13: "9780374100148",
-      status: "buzz.bookhive.defs#wantToRead",
-      reason: "no_match",
-    }, {
-      title: "Burning Chrome",
-      author: "William Gibson",
-      stars: 9,
-      finishedAt: "2025-01-23T00:00:00.000Z",
-      status: "buzz.bookhive.defs#finished",
-      reason: "no_match",
-    }]);
+    expect(complete.failedBookDetails).toMatchObject([
+      {
+        title: "2666",
+        author: "Roberto Bolaño, Natasha Wimmer (Translator)",
+        isbn10: "0374100144",
+        isbn13: "9780374100148",
+        status: "buzz.bookhive.defs#wantToRead",
+        reason: "no_match",
+      },
+      {
+        title: "Burning Chrome",
+        author: "William Gibson",
+        stars: 9,
+        finishedAt: "2025-01-23T00:00:00.000Z",
+        status: "buzz.bookhive.defs#finished",
+        reason: "no_match",
+      },
+    ]);
   });
 });

--- a/src/workers/import/import-logic.test.ts
+++ b/src/workers/import/import-logic.test.ts
@@ -5,6 +5,7 @@ import { wrapBunSqliteForKysely } from "../../bun-sqlite-kysely";
 import { migrateToLatest, type DatabaseSchema } from "../../db";
 import type { ImportContext } from "./types";
 import type { SessionClient } from "../../auth/client";
+import { processHardcoverImport } from "./logic";
 
 // Mock getUserRepoRecords to avoid needing valid CAR data from a real PDS
 const mockGetUserRepoRecords = mock(async () => ({
@@ -270,5 +271,60 @@ describe("processStorygraphImport", () => {
     expect(complete.stageProgress.total).toBe(2);
     expect(complete.failedBooks).toHaveLength(1);
     expect(complete.failedBooks[0].title).toBe("The Left Hand of Darkness");
+  });
+});
+
+export const HARDCOVER_CSV = `Title,Author,Series,Status,Privacy,Hardcover Book ID,Hardcover Edition ID,ISBN 10,ISBN 13,ASIN,Media,Country Code,Language Code,Binding,Pages,Duration in Seconds,Publish Date,Publisher,Genres,Moods,Tags,Content Warnings,Lists,Date Added,Date Started,Date Finished,Rating,Review,Review Contains Spoilers,Sponsored Review,Review Date,Review URL,Review Media URL,Private Notes,Owned,Compilation,Review Slate
+2666,"Roberto Bolaño, Natasha Wimmer (Translator)",2666 (#1.0),Want to Read,Public,75726,25012766,0374100144,9780374100148,0374100144,Book,us,en,,898,,2008-11-11,"Farrar, Straus and Giroux",,,,,"",2025-01-15,"","",,,false,false,2025-01-15T13:56:31Z,,,,false,No,{}
+Burning Chrome,William Gibson,Sprawl (#0.0),Read,Public,2440,31159321,,,B0036G94XY,Audio,us,en,,191,25686,1986-04-01,Audible Frontiers,,,,,"Owned, Shelved By Genre Reading List (#19)",2025-01-10,2025-01-01,2025-01-23,4.5,,false,false,2025-01-10T17:21:40Z,,,,true,No,{}
+Hyperion,Dan Simmons,Hyperion Cantos (#1.0),Currently Reading,Public,427460,30428122,0385263481,9780385263481,,Book,us,en,,492,,1989-05-26,Crown,,,,,Owned,2025-01-15,2025-01-25,,,,false,false,2025-01-15T13:56:57Z,,,"",true,No,{}`;
+
+describe("processHardcoverImport", () => {
+  it("emits correct SSE lifecycle events for StoryGraph CSV", async () => {
+    const { db, sqlite } = await createTestDb();
+    seedHiveBook(
+      sqlite,
+      "bk_omw",
+      "Hyperion",
+      "Dan Simmons",
+      "https://covers.example/omw.jpg",
+    );
+
+    const ctx = createMockCtx(db);
+    const agent = createMockAgent();
+    const sseEvents: any[] = [];
+
+    await processHardcoverImport({
+      csvData: new TextEncoder().encode(HARDCOVER_CSV).buffer as ArrayBuffer,
+      ctx,
+      agent,
+      onSSE: (data) => {
+        sseEvents.push(JSON.parse(data));
+      },
+    });
+
+    const eventTypes = sseEvents.map((e) => e.event);
+    expect(eventTypes).toContain("import-start");
+    expect(eventTypes).toContain("import-complete");
+
+    const complete = sseEvents.find((e) => e.event === "import-complete");
+    expect(complete.stageProgress.current).toBe(1);
+    expect(complete.stageProgress.total).toBe(3);
+    expect(complete.failedBooks).toHaveLength(2);
+    expect(complete.failedBookDetails).toMatchObject([{
+      title: "2666",
+      author: "Roberto Bolaño, Natasha Wimmer (Translator)",
+      isbn10: "0374100144",
+      isbn13: "9780374100148",
+      status: "buzz.bookhive.defs#wantToRead",
+      reason: "no_match",
+    }, {
+      title: "Burning Chrome",
+      author: "William Gibson",
+      stars: 9,
+      finishedAt: "2025-01-23T00:00:00.000Z",
+      status: "buzz.bookhive.defs#finished",
+      reason: "no_match",
+    }]);
   });
 });

--- a/src/workers/import/import-simulation.test.ts
+++ b/src/workers/import/import-simulation.test.ts
@@ -1,7 +1,7 @@
 /**
  * Simulated integration tests for the import pipeline.
  *
- * Uses real CSV rows from actual Goodreads/StoryGraph exports, with mocked
+ * Uses real CSV rows from actual Goodreads/StoryGraph/Hardcover exports, with mocked
  * network calls that use realistic delays based on measured latencies:
  *
  *   findBookDetails (Goodreads scraper):  p50 ~270ms, p90 ~650ms, max ~650ms

--- a/src/workers/import/index.ts
+++ b/src/workers/import/index.ts
@@ -3,9 +3,9 @@
  * Receives an ImportRequest via postMessage, processes the import,
  * and relays SSE events back to the main thread.
  */
-import type { ImportRequest, ImportWorkerMessage } from "./types";
+import { ImportType, type ImportRequest, type ImportWorkerMessage } from "./types";
 import { createWorkerContext } from "./context";
-import { processGoodreadsImport, processStorygraphImport } from "./logic";
+import { processGoodreadsImport, processStorygraphImport, processHardcoverImport } from "./logic";
 
 declare var self: Worker;
 
@@ -19,10 +19,12 @@ self.onmessage = async (event: MessageEvent<ImportRequest>) => {
       self.postMessage({ type: "sse", data } satisfies ImportWorkerMessage);
     };
 
-    if (type === "goodreads") {
+    if (type === ImportType.goodreads) {
       await processGoodreadsImport({ csvData, ctx, agent, onSSE });
-    } else if (type === "storygraph") {
+    } else if (type === ImportType.storygraph) {
       await processStorygraphImport({ csvData, ctx, agent, onSSE });
+    } else if (type === ImportType.hardcover) {
+      await processHardcoverImport({ csvData, ctx, agent, onSSE });
     } else {
       throw new Error(`Unknown import type: ${type as never as string}`);
     }

--- a/src/workers/import/logic.ts
+++ b/src/workers/import/logic.ts
@@ -11,8 +11,11 @@ import { Book as BookRecord } from "../../bsky/lexicon";
 import {
   getGoodreadsCsvParser,
   getStorygraphCsvParser,
+  getHardcoverCsvParser,
+  parseHardcoverRecord,
   type GoodreadsBook,
   type StorygraphBook,
+  type HardcoverBook,
 } from "../../utils/csv";
 import { getUserRepoRecords, updateBookRecords, updateBookRecord } from "../../utils/getBook";
 import {
@@ -24,6 +27,9 @@ import {
   buildGoodreadsBookRecord,
   buildStorygraphBookRecord,
   deduplicateUnmatchedWithDetails,
+  mergeHardcoverIdentifiers,
+  buildHardcoverBookRecord,
+  mapHardcoverStatus,
 } from "../../utils/importBook";
 // Note: Worker threads get isolated metric registries, so metrics here won't appear
 // at the main /metrics endpoint. The main thread (routes/import.ts) tracks import
@@ -626,6 +632,212 @@ export async function processStorygraphImport({
             review: b.book.review || undefined,
             finishedAt: b.book.lastDateRead ? b.book.lastDateRead.toISOString() : undefined,
             status: mapStorygraphStatus(b.book),
+            reason: b.reason,
+          };
+        },
+      ),
+      id: id.value++,
+    }),
+  );
+}
+
+// ─── Hardcover ──────────────────────────────────────────────────────────────
+
+export async function processHardcoverImport({
+  csvData,
+  ctx,
+  agent,
+  onSSE,
+}: {
+  csvData: ArrayBuffer;
+  ctx: ImportContext;
+  agent: SessionClient;
+  onSSE: (data: string) => void | Promise<void>;
+}): Promise<void> {
+  const id = { value: 0 };
+  const matchedBooks = { value: 0 };
+  const uploadedBooks = { value: 0 };
+  const unmatchedBooks: Array<{ book: HardcoverBook; reason: string }> = [];
+  const unmatchedSet = new Set<string>();
+
+  await onSSE(
+    sseJSON({
+      event: "import-start",
+      stage: "initializing",
+      stageProgress: { message: "Reading CSV file..." },
+      id: id.value++,
+    }),
+  );
+
+  const allBooks = await drainStream(
+    new Blob([csvData]).stream().pipeThrough(getHardcoverCsvParser()),
+  );
+  const totalBooks = allBooks.length;
+
+  const bookRecords = getUserRepoRecords({ ctx, agent });
+  const existingHiveIdsPromise = bookRecords.then(
+    (br) => new Set(br.books.values().map((b) => b.hiveId)),
+  );
+
+  let currentBatch = new Map<HiveId, BookUpdate>();
+  const hcFallback = (bu: BookUpdate): HardcoverBook => {
+    return parseHardcoverRecord({
+      Author: bu.authors || "Unknown",
+      Rating: `${bu.stars}`,
+      Review: bu.review || "",
+    });
+  };
+
+  for (let i = 0; i < allBooks.length; i += SEARCH_CONCURRENCY) {
+    const chunk = allBooks.slice(i, i + SEARCH_CONCURRENCY);
+
+    // Fire all searches in this chunk (non-blocking)
+    const searches = chunk.map((book) => searchBooks({ query: book.title, ctx }));
+
+    for (let j = 0; j < chunk.length; j++) {
+      const book = chunk[j]!;
+      const bookIdx = i + j;
+
+      await onSSE(
+        sseJSON({
+          title: book.title,
+          author: book.author,
+          processed: matchedBooks.value,
+          failed: unmatchedBooks.length,
+          total: totalBooks,
+          event: "book-load",
+          stage: "searching",
+          stageProgress: {
+            current: bookIdx + 1,
+            total: totalBooks,
+            message: `Looking up "${book.title}"…`,
+          },
+          id: id.value++,
+        }),
+      );
+
+      await searches[j];
+
+      const hiveBook = await ctx.db
+        .selectFrom("hive_book")
+        .select(["id", "title", "cover", "identifiers"])
+        .where("hive_book.rawTitle", "=", book.title)
+        .where("authors", "=", book.author)
+        .executeTakeFirst();
+
+      if (!hiveBook) {
+        const key = `${normalizeStr(book.title)}::${normalizeStr(book.author)}`;
+        if (!unmatchedSet.has(key)) {
+          unmatchedSet.add(key);
+          unmatchedBooks.push({ book, reason: "no_match" });
+        }
+        continue;
+      }
+
+      const existingIdentifiers: BookIdentifiers = hiveBook.identifiers
+        ? JSON.parse(hiveBook.identifiers)
+        : {};
+      const { identifiers: newIdentifiers, changed } = mergeHardcoverIdentifiers({
+        isbn10: book.isbn10,
+        isbn13: book.isbn13,
+        existingIdentifiers,
+        hiveBookId: hiveBook.id,
+      });
+      if (changed) {
+        const updatedAt = new Date().toISOString();
+        await ctx.db
+          .updateTable("hive_book")
+          .set({
+            identifiers: JSON.stringify(newIdentifiers),
+            updatedAt,
+          })
+          .where("id", "=", hiveBook.id)
+          .execute();
+        // Keep book_id_map in sync so findBookIdentifiersByLookup sees the merged IDs
+        await ctx.db
+          .insertInto("book_id_map")
+          .values({
+            hiveId: hiveBook.id as HiveId,
+            isbn: newIdentifiers.isbn10 ?? null,
+            isbn13: newIdentifiers.isbn13 ?? null,
+            goodreadsId: newIdentifiers.goodreadsId ?? null,
+            updatedAt,
+          })
+          .onConflict((oc) =>
+            oc.column("hiveId").doUpdateSet((eb) => ({
+              isbn: eb.ref("excluded.isbn"),
+              isbn13: eb.ref("excluded.isbn13"),
+              goodreadsId: eb.ref("excluded.goodreadsId"),
+              updatedAt: eb.ref("excluded.updatedAt"),
+            })),
+          )
+          .execute();
+      }
+
+      const existingHiveIds = await existingHiveIdsPromise;
+      currentBatch.set(
+        hiveBook.id as HiveId,
+        buildHardcoverBookRecord({ book, hiveBook, existingHiveIds }),
+      );
+
+      if (currentBatch.size >= BATCH_SIZE) {
+        await flushBatch({
+          batch: currentBatch,
+          ctx,
+          agent,
+          bookRecords,
+          onSSE,
+          id,
+          matchedBooks,
+          uploadedBooks,
+          unmatchedBooks,
+          totalBooks,
+          makeFallbackBook: hcFallback,
+        });
+        currentBatch = new Map();
+      }
+    }
+  }
+
+  await flushBatch({
+    batch: currentBatch,
+    ctx,
+    agent,
+    bookRecords,
+    onSSE,
+    id,
+    matchedBooks,
+    uploadedBooks,
+    unmatchedBooks,
+    totalBooks,
+    makeFallbackBook: hcFallback,
+  });
+
+  await onSSE(
+    sseJSON({
+      event: "import-complete",
+      stage: "complete",
+      stageProgress: {
+        current: matchedBooks.value,
+        total: totalBooks,
+        message: `Import complete! Successfully imported ${uploadedBooks.value} books${unmatchedBooks.length > 0 ? ` (${unmatchedBooks.length} failed)` : ""}`,
+      },
+      ...deduplicateUnmatchedWithDetails(
+        unmatchedBooks,
+        (b) => b.title,
+        (b) => b.author,
+        (b) => {
+          const cleanIsbn = b.book.isbn10?.replace(/[-\s]/g, "") || "";
+          const cleanIsbn13 = b.book.isbn13?.replace(/[-\s]/g, "") || "";
+          return {
+            title: b.book.title,
+            author: b.book.author,
+            isbn10: cleanIsbn.length === 10 ? cleanIsbn : undefined,
+            isbn13: cleanIsbn13.length === 13 ? cleanIsbn13 : undefined,
+            stars: b.book.rating || undefined,
+            review: b.book.review || undefined,
+            finishedAt: b.book.dateFinished ? b.book.dateFinished.toISOString() : undefined,
+            status: mapHardcoverStatus(b.book),
             reason: b.reason,
           };
         },

--- a/src/workers/import/logic.ts
+++ b/src/workers/import/logic.ts
@@ -6,7 +6,7 @@
  * SSE progress so the user always sees what's happening.
  */
 import type { SessionClient } from "../../auth/client";
-import type { BookIdentifiers, HiveId } from "../../types";
+import { type BookIdentifiers, type HiveId } from "../../types";
 import { Book as BookRecord } from "../../bsky/lexicon";
 import {
   getGoodreadsCsvParser,
@@ -24,12 +24,11 @@ import {
   mapStorygraphStatus,
   mergeGoodreadsIdentifiers,
   mergeStorygraphIdentifiers,
+  mergeHardcoverIdentifiers,
   buildGoodreadsBookRecord,
   buildStorygraphBookRecord,
-  deduplicateUnmatchedWithDetails,
-  mergeHardcoverIdentifiers,
   buildHardcoverBookRecord,
-  mapHardcoverStatus,
+  deduplicateUnmatchedWithDetails,
 } from "../../utils/importBook";
 // Note: Worker threads get isolated metric registries, so metrics here won't appear
 // at the main /metrics endpoint. The main thread (routes/import.ts) tracks import
@@ -683,8 +682,13 @@ export async function processHardcoverImport({
   const hcFallback = (bu: BookUpdate): HardcoverBook => {
     return parseHardcoverRecord({
       Author: bu.authors || "Unknown",
-      Rating: `${bu.stars}`,
+      "Date Added": bu.createdAt ?? "",
+      "Date Started": bu.startedAt ?? "",
+      "Date Finished": bu.finishedAt ?? "",
+      Rating: `${(bu.stars || 0) / 2}`,
       Review: bu.review || "",
+      Status: bu.status || "",
+      Title: bu.title || "Unknown",
     });
   };
 
@@ -738,8 +742,7 @@ export async function processHardcoverImport({
         ? JSON.parse(hiveBook.identifiers)
         : {};
       const { identifiers: newIdentifiers, changed } = mergeHardcoverIdentifiers({
-        isbn10: book.isbn10,
-        isbn13: book.isbn13,
+        book,
         existingIdentifiers,
         hiveBookId: hiveBook.id,
       });
@@ -827,17 +830,17 @@ export async function processHardcoverImport({
         (b) => b.title,
         (b) => b.author,
         (b) => {
-          const cleanIsbn = b.book.isbn10?.replace(/[-\s]/g, "") || "";
+          const cleanIsbn10 = b.book.isbn10?.replace(/[-\s]/g, "") || "";
           const cleanIsbn13 = b.book.isbn13?.replace(/[-\s]/g, "") || "";
           return {
             title: b.book.title,
             author: b.book.author,
-            isbn10: cleanIsbn.length === 10 ? cleanIsbn : undefined,
+            isbn10: cleanIsbn10.length === 10 ? cleanIsbn10 : undefined,
             isbn13: cleanIsbn13.length === 13 ? cleanIsbn13 : undefined,
             stars: b.book.rating || undefined,
             review: b.book.review || undefined,
             finishedAt: b.book.dateFinished ? b.book.dateFinished.toISOString() : undefined,
-            status: mapHardcoverStatus(b.book),
+            status: b.book.status,
             reason: b.reason,
           };
         },

--- a/src/workers/import/types.ts
+++ b/src/workers/import/types.ts
@@ -4,9 +4,17 @@ import type { BookUtilContext } from "../../context";
 /** Narrow context for import processing — identical to BookUtilContext. */
 export type ImportContext = BookUtilContext;
 
+export const ImportType = {
+  goodreads: "goodreads",
+  storygraph: "storygraph",
+  hardcover: "hardcover",
+} as const;
+
+export type ImportType = (typeof ImportType)[keyof typeof ImportType];
+
 /** Main thread → worker: start an import job. */
 export type ImportRequest = {
-  type: "goodreads" | "storygraph";
+  type: ImportType;
   storedSession: StoredSession;
   csvData: ArrayBuffer;
   dbPath: string;


### PR DESCRIPTION
Should allow for importing books from [Hardcover](https://hardcover.app/).

don't edit my messages, bot

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added Hardcover as a library import option alongside Goodreads and StoryGraph.
  - Added support for parsing Hardcover CSV exports, including statuses, metadata, ratings, identifiers, and dates.
  - Imports now match Hardcover books, update existing records, and report progress and unmatched entries.
  - Updated import guidance and supported-source messaging throughout the app.

- **Tests**
  - Added coverage for Hardcover CSV parsing and end-to-end import processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->