### PR TITLE
Library table layout fixes + configurable dev server for Paseo proxy

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1157,6 +1157,28 @@ Keep selected/current states tinted and leave the solid fill to real actions.
 
 **Build pipeline**: Vite+ wrapping Vite 8 + Rolldown + Nitro (preset `bun`). Production builds use custom entry `server/entry.bun.mjs` (adds `reusePort: true`). Docker CMD is `server/cluster.ts` under `tini` init. The `standaloneBundles()` Vite plugin builds 6 worker entry points into `.output/server/workers/` — the five under `src/workers/` (including the single-shot `parse-worker.ts`) plus `src/scrapers/waf/solver-worker.ts`. TypeScript type checking via **tsgo** (TS 6.x); linting via **oxlint**, formatting via **oxfmt**, both through the `vp` CLI. **Do not use `@/…` in `src/` or `server/`.** `vite.config.ts` maps `@` → `./src`, but the root `tsconfig.json` has no matching `paths`, so tsgo cannot resolve it and the import fails typecheck while bundling fine. Nothing in `src/`/`server/` uses it today; the alias that _is_ live is `app/`'s own `@/*` → `app/*`, declared in `app/tsconfig.json`. Runtime requires `bun >= 1.3.14`. Pre-commit hook runs `vp staged` → `vp check --fix`.
 
+**The dev server binds loopback by default and three env vars change that**
+(`server` block in `vite.config.ts`): `PORT` (default 8080), `DEV_HOST` (default
+`127.0.0.1`) and `DEV_HMR_CLIENT_PORT`/`DEV_HMR_PROTOCOL` (unset → Vite's own
+inference). They exist so the dev server can be published to a
+TLS-terminating reverse proxy without editing the config: the proxy sees plain
+HTTP on the origin port, so the HMR client has to be told the scheme and port to
+dial or the page loads and then never live-reloads. `paseo.json`'s `dev` service
+script sets all three (`PORT=$PASEO_PORT DEV_HOST=0.0.0.0
+DEV_HMR_CLIENT_PORT=443`).
+
+**`PUBLIC_URL` decides which OAuth client the dev server is**, and getting it
+wrong breaks sign-in in one of two ways. Empty or `127.0.0.1`/`localhost` takes
+the loopback branch in `src/auth/client.ts`, which sets **no `client_id` at
+all** — loopback clients need no metadata document, which is why plain local dev
+logs in with no setup. Any other value makes it a real public client identified
+by `<PUBLIC_URL>/oauth-client-metadata.json`, and that URL is fetched by the
+**user's PDS**, server-side and with no session — so it must be reachable and
+unauthenticated from the public internet, and the browser's origin must match it
+or the callback lands somewhere the browser cannot follow. `paseo.json` sets
+`PUBLIC_URL=https://$PASEO_PORT.dev.nickthesick.com` for that reason; the port
+is allocated per start, so the value is derived, never hardcoded.
+
 Notable deps: hono, kysely, zod 4, iron-session, unstorage + ocache, `@atcute/*`, `@takumi-rs/image-response` + React 19 (OG only), pino, `@hono/prometheus`, `@opentelemetry/*`, basecoat-css, envalid.
 
 **`bunfig.toml` preloads `src/test/env-setup.ts`, and that is load-bearing.**

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1157,15 +1157,32 @@ Keep selected/current states tinted and leave the solid fill to real actions.
 
 **Build pipeline**: Vite+ wrapping Vite 8 + Rolldown + Nitro (preset `bun`). Production builds use custom entry `server/entry.bun.mjs` (adds `reusePort: true`). Docker CMD is `server/cluster.ts` under `tini` init. The `standaloneBundles()` Vite plugin builds 6 worker entry points into `.output/server/workers/` — the five under `src/workers/` (including the single-shot `parse-worker.ts`) plus `src/scrapers/waf/solver-worker.ts`. TypeScript type checking via **tsgo** (TS 6.x); linting via **oxlint**, formatting via **oxfmt**, both through the `vp` CLI. **Do not use `@/…` in `src/` or `server/`.** `vite.config.ts` maps `@` → `./src`, but the root `tsconfig.json` has no matching `paths`, so tsgo cannot resolve it and the import fails typecheck while bundling fine. Nothing in `src/`/`server/` uses it today; the alias that _is_ live is `app/`'s own `@/*` → `app/*`, declared in `app/tsconfig.json`. Runtime requires `bun >= 1.3.14`. Pre-commit hook runs `vp staged` → `vp check --fix`.
 
-**The dev server binds loopback by default and three env vars change that**
+**The dev server binds loopback by default and four env vars change that**
 (`server` block in `vite.config.ts`): `PORT` (default 8080), `DEV_HOST` (default
-`127.0.0.1`) and `DEV_HMR_CLIENT_PORT`/`DEV_HMR_PROTOCOL` (unset → Vite's own
-inference). They exist so the dev server can be published to a
+`127.0.0.1`), `DEV_HMR_CLIENT_PORT` (unset → Vite's own inference) and
+`DEV_HMR_PROTOCOL` (**defaults to `wss`** whenever `DEV_HMR_CLIENT_PORT` is set —
+the whole point of setting it is that the proxy terminates TLS, so `ws` would be
+blocked as mixed content). They exist so the dev server can be published to a
 TLS-terminating reverse proxy without editing the config: the proxy sees plain
-HTTP on the origin port, so the HMR client has to be told the scheme and port to
+HTTP on the origin port, so the WS client has to be told the scheme and port to
 dial or the page loads and then never live-reloads. `paseo.json`'s `dev` service
-script sets all three (`PORT=$PASEO_PORT DEV_HOST=0.0.0.0
-DEV_HMR_CLIENT_PORT=443`).
+script sets `PORT`, `DEV_HOST=0.0.0.0` and `DEV_HMR_CLIENT_PORT=443`.
+
+Three things about that block are easy to get wrong:
+
+- **The options are `server.ws.protocol`/`server.ws.clientPort`.** Vite 8 still
+  accepts them under `server.hmr`, but every one of `HmrOptions`' transport
+  fields is deprecated there in favour of `server.ws` (`overlay` is the only one
+  that isn't).
+- **`strictPort` is on whenever `PORT` is set**, because a proxy routes one fixed
+  port at us — silently falling back to the next free port leaves the dev server
+  running somewhere nothing is routed to, which reads as "the proxy is broken".
+  The 8080 default keeps Vite's fallback.
+- **`allowedHosts` names the `PUBLIC_URL` hostname; it is not `true`.** `true`
+  disables host checking altogether, which is a DNS-rebinding hole for any dev
+  server not on loopback. Nothing extra to configure — a proxied dev server has
+  to set `PUBLIC_URL` anyway (see below) — and localhost and bare IPs are
+  allowed by Vite unconditionally, so plain local dev is unaffected.
 
 **`PUBLIC_URL` decides which OAuth client the dev server is**, and getting it
 wrong breaks sign-in in one of two ways. Empty or `127.0.0.1`/`localhost` takes
@@ -1176,8 +1193,10 @@ by `<PUBLIC_URL>/oauth-client-metadata.json`, and that URL is fetched by the
 **user's PDS**, server-side and with no session — so it must be reachable and
 unauthenticated from the public internet, and the browser's origin must match it
 or the callback lands somewhere the browser cannot follow. `paseo.json` sets
-`PUBLIC_URL=https://$PASEO_PORT.dev.nickthesick.com` for that reason; the port
-is allocated per start, so the value is derived, never hardcoded.
+`PUBLIC_URL` for that reason, on a **pinned** port rather than the per-start
+`$PASEO_PORT` allocation: the session cookie is host-only, so a moving hostname
+meant signing in again after every restart. `PUBLIC_URL` is also what
+`allowedHosts` is derived from (above), so the two cannot drift apart.
 
 Notable deps: hono, kysely, zod 4, iron-session, unstorage + ocache, `@atcute/*`, `@takumi-rs/image-response` + React 19 (OG only), pino, `@hono/prometheus`, `@opentelemetry/*`, basecoat-css, envalid.
 

--- a/paseo.json
+++ b/paseo.json
@@ -1,0 +1,11 @@
+{
+  "worktree": {
+    "setup": "bun i"
+  },
+  "scripts": {
+    "dev": {
+      "type": "service",
+      "command": "PORT=$PASEO_PORT DEV_HOST=0.0.0.0 DEV_HMR_CLIENT_PORT=443 PUBLIC_URL=https://$PASEO_PORT.dev.nickthesick.com vp run dev"
+    }
+  }
+}

--- a/paseo.json
+++ b/paseo.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": {
       "type": "service",
-      "command": "PORT=$PASEO_PORT DEV_HOST=0.0.0.0 DEV_HMR_CLIENT_PORT=443 PUBLIC_URL=https://$PASEO_PORT.dev.nickthesick.com vp run dev"
+      "command": "PORT=5199 DEV_HOST=0.0.0.0 DEV_HMR_CLIENT_PORT=443 PUBLIC_URL=https://5199.dev.nickthesick.com vp run dev"
     }
   }
 }

--- a/src/client/components/LibraryTable.tsx
+++ b/src/client/components/LibraryTable.tsx
@@ -402,7 +402,7 @@ const MobileCard: FC<{
           </div>
           <button
             type="button"
-            className="mt-1 self-end rounded-md px-2 py-1.5 text-xs text-destructive transition-[color,background-color] duration-150 hover:bg-destructive/10 hover:text-destructive/80 focus:outline-none"
+            className="focus-ring mt-1 inline-flex min-h-10 min-w-10 items-center justify-center self-end rounded-md px-2 text-xs text-destructive transition-[color,background-color] duration-150 hover:bg-destructive/10 hover:text-destructive/80"
             onClick={() => {
               onDelete();
               void deleteBook(book.hiveId);
@@ -474,6 +474,9 @@ export const LibraryTable: FC<{ initialBooks: LibraryBook[] }> = ({ initialBooks
           has to fit in that. */}
       <div className="hidden max-h-[calc(100dvh-11rem)] overflow-auto rounded-xl bg-card shadow-[0_1px_3px_rgba(0,0,0,0.08),0_4px_12px_rgba(0,0,0,0.04)] xl:block">
         <table className="table w-full min-w-[880px] table-fixed">
+          {/* The only accessible name this table has: the visible "Library"
+              heading lives in the server-rendered page, outside the island. */}
+          <caption className="sr-only">Your library</caption>
           {/* The row scrolling under the pinned header needs an edge to
               disappear behind, or it dissolves into the header fill. */}
           <thead className="sticky top-0 z-10 bg-muted shadow-[inset_0_-1px_0_var(--border)]">

--- a/src/client/components/LibraryTable.tsx
+++ b/src/client/components/LibraryTable.tsx
@@ -207,7 +207,7 @@ const TableRow: FC<{
           <BookCover src={book.cover || book.thumbnail} alt={`Cover of ${book.title}`} />
         </div>
         <div className="min-w-0 flex-1">
-          <h3 className="line-clamp-1 text-sm leading-tight font-medium text-foreground">
+          <h3 className="line-clamp-1 max-w-[16rem] text-sm leading-tight font-medium text-foreground">
             {book.title}
           </h3>
           <p className="line-clamp-1 text-xs text-muted-foreground">
@@ -462,9 +462,15 @@ export const LibraryTable: FC<{ initialBooks: LibraryBook[] }> = ({ initialBooks
 
   return (
     <>
-      {/* Desktop: table view */}
-      <div className="hidden overflow-hidden rounded-xl bg-card shadow-[0_1px_3px_rgba(0,0,0,0.08),0_4px_12px_rgba(0,0,0,0.04)] md:block">
-        <table className="table w-full table-fixed">
+      {/* Desktop: table view.
+          Bounded scroll container: caps height to the viewport so the header
+          pins reliably (sticky resolves against this box's scrollport, not the
+          document — the app shell scrolls at document level, and an
+          overflow-hidden ancestor here would sink the sticky thead with the
+          page). overflow-auto also gives horizontal overflow a scrollbar on
+          medium screens instead of clipping the table content off-screen. */}
+      <div className="hidden max-h-[calc(100dvh-11rem)] overflow-auto rounded-xl bg-card shadow-[0_1px_3px_rgba(0,0,0,0.08),0_4px_12px_rgba(0,0,0,0.04)] md:block">
+        <table className="table w-full min-w-[720px] table-fixed">
           <thead className="sticky top-0 z-10 bg-muted">
             <tr>
               <th

--- a/src/client/components/LibraryTable.tsx
+++ b/src/client/components/LibraryTable.tsx
@@ -6,7 +6,6 @@ import {
   DeleteButton,
   BookCover,
   DateInput,
-  STATUS_LABELS,
   updateBook,
   deleteBook,
 } from "./bookActions";
@@ -207,7 +206,7 @@ const TableRow: FC<{
           <BookCover src={book.cover || book.thumbnail} alt={`Cover of ${book.title}`} />
         </div>
         <div className="min-w-0 flex-1">
-          <h3 className="line-clamp-1 max-w-[16rem] text-sm leading-tight font-medium text-foreground">
+          <h3 className="line-clamp-1 text-sm leading-tight font-medium text-foreground">
             {book.title}
           </h3>
           <p className="line-clamp-1 text-xs text-muted-foreground">
@@ -316,29 +315,25 @@ const MobileCard: FC<{
 
   return (
     <div className="card transition-[box-shadow] duration-150 active:shadow-none">
-      <div className="card-body flex gap-3">
-        <a href={`/books/${book.hiveId}`} className="flex flex-1 min-w-0 gap-3">
-          <div className="h-16 w-12 shrink-0 overflow-hidden rounded-sm shadow-sm outline outline-1 outline-black/10 dark:outline-white/10">
+      <div className="card-body flex flex-col items-start gap-3 sm:flex-row">
+        <a href={`/books/${book.hiveId}`} className="flex w-full min-w-0 gap-3 sm:flex-1">
+          <div className="aspect-[2/3] w-12 shrink-0 overflow-hidden rounded-sm shadow-sm outline outline-1 outline-black/10 dark:outline-white/10">
             <BookCover src={book.cover || book.thumbnail} alt={`Cover of ${book.title}`} />
           </div>
-          <div className="min-w-0 flex-1 flex flex-col justify-center">
+          <div className="min-w-0 flex-1">
             <div className="text-foreground font-semibold text-sm line-clamp-2">{book.title}</div>
             <div className="text-muted-foreground text-xs mt-0.5">
               {book.authors.split("\t").join(", ")}
             </div>
-            {book.status && (
-              <div className="mt-1 flex flex-wrap items-center gap-2">
-                <span className="badge capitalize">
-                  {STATUS_LABELS[book.status] || book.status}
-                </span>
-                {percent > 0 && book.status !== FINISHED && (
-                  <span className="text-xs tabular-nums text-muted-foreground">{percent}%</span>
-                )}
-              </div>
+            {percent > 0 && book.status !== FINISHED && (
+              <div className="mt-1 text-xs tabular-nums text-muted-foreground">{percent}% read</div>
             )}
           </div>
         </a>
-        <div className="shrink-0 flex flex-col items-stretch" onClick={(e) => e.stopPropagation()}>
+        <div
+          className="flex w-full shrink-0 flex-col items-stretch sm:w-auto"
+          onClick={(e) => e.stopPropagation()}
+        >
           <StatusSelect
             status={book.status}
             onChange={(status) => {
@@ -467,15 +462,25 @@ export const LibraryTable: FC<{ initialBooks: LibraryBook[] }> = ({ initialBooks
           pins reliably (sticky resolves against this box's scrollport, not the
           document — the app shell scrolls at document level, and an
           overflow-hidden ancestor here would sink the sticky thead with the
-          page). overflow-auto also gives horizontal overflow a scrollbar on
-          medium screens instead of clipping the table content off-screen. */}
-      <div className="hidden max-h-[calc(100dvh-11rem)] overflow-auto rounded-xl bg-card shadow-[0_1px_3px_rgba(0,0,0,0.08),0_4px_12px_rgba(0,0,0,0.04)] md:block">
-        <table className="table w-full min-w-[720px] table-fixed">
-          <thead className="sticky top-0 z-10 bg-muted">
+          page). overflow-auto is the safety net for the narrow end.
+
+          `xl`, not `md`. Six columns need ~880px, but this table renders inside
+          the app shell's max-w-5xl column *next to the sidebar*: measured
+          content width is 476px at a 820px viewport and 632px at 1024px, so
+          every width below ~1130px got a table that scrolled sideways. The card
+          view below is a better answer for that range than a table you have to
+          drag. Note the ceiling is max-w-5xl, not the viewport — content tops
+          out at ~976px however wide the screen gets, so the column budget below
+          has to fit in that. */}
+      <div className="hidden max-h-[calc(100dvh-11rem)] overflow-auto rounded-xl bg-card shadow-[0_1px_3px_rgba(0,0,0,0.08),0_4px_12px_rgba(0,0,0,0.04)] xl:block">
+        <table className="table w-full min-w-[880px] table-fixed">
+          {/* The row scrolling under the pinned header needs an edge to
+              disappear behind, or it dissolves into the header fill. */}
+          <thead className="sticky top-0 z-10 bg-muted shadow-[inset_0_-1px_0_var(--border)]">
             <tr>
               <th
                 className="cursor-pointer select-none px-4 py-2 text-left text-sm font-semibold text-foreground transition-colors hover:text-primary"
-                style={{ width: "30%" }}
+                style={{ width: "29%" }}
                 onClick={() => toggleSort("title")}
               >
                 Book
@@ -486,7 +491,7 @@ export const LibraryTable: FC<{ initialBooks: LibraryBook[] }> = ({ initialBooks
               </th>
               <th
                 className="cursor-pointer select-none px-4 py-2 text-left text-sm font-semibold text-foreground transition-colors hover:text-primary"
-                style={{ width: "13%" }}
+                style={{ width: "17%" }}
                 onClick={() => toggleSort("status")}
               >
                 Status
@@ -497,7 +502,7 @@ export const LibraryTable: FC<{ initialBooks: LibraryBook[] }> = ({ initialBooks
               </th>
               <th
                 className="cursor-pointer select-none px-4 py-2 text-left text-sm font-semibold text-foreground transition-colors hover:text-primary"
-                style={{ width: "13%", minWidth: "120px" }}
+                style={{ width: "11%" }}
                 onClick={() => toggleSort("rating")}
               >
                 Rating
@@ -508,13 +513,13 @@ export const LibraryTable: FC<{ initialBooks: LibraryBook[] }> = ({ initialBooks
               </th>
               <th
                 className="px-4 py-2 text-left text-sm font-semibold text-foreground"
-                style={{ width: "12%" }}
+                style={{ width: "13%" }}
               >
                 Progress
               </th>
               <th
                 className="cursor-pointer select-none px-4 py-2 text-left text-sm font-semibold whitespace-nowrap text-foreground transition-colors hover:text-primary"
-                style={{ width: "14%" }}
+                style={{ width: "20%" }}
                 onClick={() => toggleSort("date")}
               >
                 Dates
@@ -522,7 +527,7 @@ export const LibraryTable: FC<{ initialBooks: LibraryBook[] }> = ({ initialBooks
               </th>
               <th
                 className="px-4 py-2 text-left text-sm font-semibold text-foreground"
-                style={{ width: "6%" }}
+                style={{ width: "10%" }}
               >
                 Actions
               </th>
@@ -542,7 +547,7 @@ export const LibraryTable: FC<{ initialBooks: LibraryBook[] }> = ({ initialBooks
       </div>
 
       {/* Mobile: card view */}
-      <div className="space-y-4 md:hidden">
+      <div className="space-y-4 xl:hidden">
         <div className="flex items-center gap-2">
           <label className="text-xs font-medium text-muted-foreground">Sort by</label>
           <select
@@ -564,7 +569,7 @@ export const LibraryTable: FC<{ initialBooks: LibraryBook[] }> = ({ initialBooks
           </select>
         </div>
       </div>
-      <div className="space-y-4 md:hidden">
+      <div className="space-y-4 xl:hidden">
         {sortedBooks.map((book) => (
           <MobileCard
             key={book.hiveId}

--- a/src/client/components/bookActions.tsx
+++ b/src/client/components/bookActions.tsx
@@ -75,7 +75,10 @@ export const RatingSelect: FC<{
 export const DeleteButton: FC<{ onDelete: () => void }> = ({ onDelete }) => (
   <button
     type="button"
-    className="inline-flex items-center rounded-md p-2 text-red-600 hover:bg-red-50 hover:text-red-700 focus:ring-2 focus:ring-red-500 focus:ring-offset-2 focus:outline-none dark:text-red-400 dark:hover:bg-red-900/20 dark:hover:text-red-300"
+    // min-h-10/min-w-10 is the house tap-target floor; p-2 around a 16px icon
+    // was a 32px hit area. The table row is ~73px tall (the stacked date
+    // inputs set it), so the larger target costs no row height.
+    className="focus-ring inline-flex min-h-10 min-w-10 items-center justify-center rounded-md text-destructive transition-[color,background-color] duration-150 hover:bg-destructive/10 hover:text-destructive/80"
     title="Delete book from library"
     onClick={onDelete}
   >

--- a/src/client/components/bookActions.tsx
+++ b/src/client/components/bookActions.tsx
@@ -66,8 +66,7 @@ export const RatingSelect: FC<{
     <option value="">-</option>
     {[1, 2, 3, 4, 5, 6, 7, 8, 9, 10].map((val) => (
       <option key={val} value={val}>
-        {"★".repeat(Math.floor(val / 2))}
-        {val % 2 === 1 ? "½" : ""} {(val / 2).toFixed(1)}
+        {(val / 2).toFixed(1)}
       </option>
     ))}
   </select>

--- a/src/pages/import.tsx
+++ b/src/pages/import.tsx
@@ -21,7 +21,7 @@ export const LibraryImport: FC = () => {
                   name="import-service"
                   value="goodreads"
                   class="peer sr-only"
-                  defaultChecked
+                  checked
                 />
                 <div class="card flex flex-1 items-center px-4 py-3 shadow-sm min-h-[44px] transition-[box-shadow,background-color] duration-150 peer-checked:shadow-[0_0_0_2px_var(--primary)] peer-checked:bg-primary/5 hover:shadow-md min-w-[140px]">
                   <span class="font-medium text-foreground">From Goodreads</span>

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -142,6 +142,21 @@ function devImageProxyPassthrough(): Plugin {
   };
 }
 
+// The hostname the dev server is reached on through a TLS-terminating proxy.
+// PUBLIC_URL is the same value the user's PDS fetches our OAuth client metadata
+// from, so there is nothing extra to configure. Loopback needs no entry — Vite
+// allows localhost and bare IPs unconditionally.
+const publicHostname = (() => {
+  const url = process.env["PUBLIC_URL"];
+  if (!url) return null;
+  try {
+    const { hostname } = new URL(url);
+    return hostname === "localhost" || hostname === "127.0.0.1" ? null : hostname;
+  } catch {
+    return null;
+  }
+})();
+
 // eslint-disable-next-line @typescript-eslint/no-explicit-any -- vite-plus extends the config type beyond what defineConfig accepts
 export default defineConfig(({ command }): any => ({
   staged: {
@@ -218,11 +233,20 @@ export default defineConfig(({ command }): any => ({
     // container-external proxy (see the dev-server note in AGENTS.md).
     host: process.env["DEV_HOST"] || "127.0.0.1",
     port: Number(process.env["PORT"]) || 8080,
-    allowedHosts: true,
-    // When reached through a TLS-terminating proxy the HMR client must be told
+    // The proxy routes a fixed port at us, so falling back to the next free one
+    // would leave the dev server running somewhere nothing is routed to. Only
+    // when PORT was chosen for us — the 8080 default keeps Vite's own fallback.
+    strictPort: Boolean(process.env["PORT"]),
+    // `true` disables host checking entirely, which is a DNS-rebinding hole for
+    // any dev server not on loopback. Vite always allows localhost and bare IPs,
+    // so this only has to name the proxy's hostname — which PUBLIC_URL already
+    // is, since the user's PDS has to fetch the client metadata from it.
+    allowedHosts: publicHostname ? [publicHostname] : [],
+    // When reached through a TLS-terminating proxy the WS client must be told
     // the scheme/port it should dial, since it can't infer them from the
-    // origin port the dev server itself is listening on.
-    hmr: process.env["DEV_HMR_CLIENT_PORT"]
+    // origin port the dev server itself is listening on. `server.hmr.protocol`
+    // and `.clientPort` are deprecated aliases of these in Vite 8.
+    ws: process.env["DEV_HMR_CLIENT_PORT"]
       ? {
           protocol: process.env["DEV_HMR_PROTOCOL"] || "wss",
           clientPort: Number(process.env["DEV_HMR_CLIENT_PORT"]),

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -215,7 +215,7 @@ export default defineConfig(({ command }): any => ({
   ],
   server: {
     // Loopback by default. Set DEV_HOST=0.0.0.0 to publish the dev server to a
-    // container-external proxy (see docs/dev-server.md).
+    // container-external proxy (see the dev-server note in AGENTS.md).
     host: process.env["DEV_HOST"] || "127.0.0.1",
     port: Number(process.env["PORT"]) || 8080,
     allowedHosts: true,

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -214,9 +214,20 @@ export default defineConfig(({ command }): any => ({
     }),
   ],
   server: {
-    host: "127.0.0.1",
-    port: 8080,
+    // Loopback by default. Set DEV_HOST=0.0.0.0 to publish the dev server to a
+    // container-external proxy (see docs/dev-server.md).
+    host: process.env["DEV_HOST"] || "127.0.0.1",
+    port: Number(process.env["PORT"]) || 8080,
     allowedHosts: true,
+    // When reached through a TLS-terminating proxy the HMR client must be told
+    // the scheme/port it should dial, since it can't infer them from the
+    // origin port the dev server itself is listening on.
+    hmr: process.env["DEV_HMR_CLIENT_PORT"]
+      ? {
+          protocol: process.env["DEV_HMR_PROTOCOL"] || "wss",
+          clientPort: Number(process.env["DEV_HMR_CLIENT_PORT"]),
+        }
+      : undefined,
   },
   root: ".",
   publicDir: "public",


### PR DESCRIPTION
## Summary

Two things: makes the dev server reachable through a TLS-terminating reverse proxy, and fixes the library table's layout across every width.

Rebased onto `main`, so this now sits on top of the sortable columns (`a3ae4db`) and the reading-progress column (`301a235`) rather than conflicting with them.

## Dev server (`vite.config.ts`, `paseo.json`, `AGENTS.md`)

- `DEV_HOST`, `PORT`, `DEV_HMR_CLIENT_PORT` and `DEV_HMR_PROTOCOL` configure the dev server. Defaults are unchanged — loopback on 8080 — so a plain `bun run dev` behaves exactly as before.
- The HMR vars exist because the proxy terminates TLS while the dev server sees plain HTTP on its own port; without being told the scheme and port to dial, the page loads and then never live-reloads.
- `paseo.json` adds the dev service script and worktree setup, with a **fixed** port. Paseo allocates a fresh `$PASEO_PORT` per start, so the URL moved on every restart and the host-only session cookie didn't follow it — signing in again each time. Trade-off: Paseo health-probes the port it handed out, so `paseo script ls` reports the service unhealthy and its `localhost:6767` proxy won't resolve. It does not restart the service on that.
- `AGENTS.md` documents the vars and, separately, how `PUBLIC_URL` picks the OAuth client: empty or loopback sets **no `client_id` at all** (loopback clients need no metadata document — this is why local dev signs in with no setup), while any other value makes it a public client whose `/oauth-client-metadata.json` the *user's PDS* fetches server-side, so it has to be publicly reachable and the browser origin has to match.

## Library table

Every number below was measured in the running app, after the rebase.

**Table (`xl`+)**

- The six column widths **summed to 88%**, so the browser scaled all of them by an arbitrary 1.14. Now 29/17/11/13/20/10 = 100%, sized so each header fits its label *plus* the `SortArrow`. `Rating` still carried `minWidth:120px` from when its options read `★★½ 4.0`; those are plain numbers now, so it is 98px. `Actions` was 6% — not enough for the word "Actions" plus its `px-4` gutters.
- Dropped `max-w-[16rem]` from the title. With the Progress column added upstream the Book column is 258–278px, so the clamp no longer binds at all — it was inert and misleading rather than harmful.
- The sticky `thead` had no bottom edge, so rows dissolved into its fill while scrolling under it.

**Breakpoint `md` → `xl`**

Six columns need ~880px, but the table renders *beside the sidebar* inside the shell's `max-w-5xl` column: content is **476px at a 820px viewport and 632px at 1024px**. Every width from 768 to ~1130 got a table that scrolled sideways. The card view serves that range better. Worth knowing: the ceiling is `max-w-5xl`, not the viewport — content tops out at ~976px however wide the screen gets, which is the real budget the columns have to fit in. Verified at 1280 (the tightest case, content 888px) and 1440: zero horizontal overflow, all six headers fit.

**Cards (now 0–1279px, not phones only)**

- Cover box was 48×64 (**0.75**) while the artwork is 2:3 (measured 1796×2701 = **0.665**), so `object-cover` cropped ~11% off every cover.
- Cover top 141, select top 141, **title top 158** — the title was `justify-center`'d inside a column stretched by the taller controls. Three anchors in one row; all three now start together.
- **The phone view was overlapping.** The controls column is `shrink-0` and needs ~280px; at 390px that left ~34px for the book, so cover and title rendered *underneath* the select. Stacked below `sm` — verified no overlap, 128px date inputs, no document overflow.
- Dropped the status badge that restated the `StatusSelect` 8px to its right. **The reading-progress percent that upstream put next to it is kept** — that is the one thing in that row the select doesn't already say.
- Both `xl:hidden` blocks moved together, including the mobile sort dropdown `a3ae4db` added.

**`bookActions.tsx`**

- Rating options show the numeric value (`2.5`) rather than `★★½ 2.5`.
- `DeleteButton` was a 32px hit area, under the `min-h-10` floor AGENTS.md sets, and hardcoded `red-600` while the card's Remove used `text-destructive`. Now 40px and on the token. Shared with `ImportTableApp`, which was under the floor for the same reason.

## Testing

`bun run lint` (oxlint + tsgo type-check) clean. Verified in a browser at 390, 1280 and 1440px: no horizontal overflow, every header label fits, correct 2:3 cover ratio, and no overlap in the card view.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable development server host, port, and hot-reload connection settings.
  * Added worktree development setup and service configuration.

* **UI Improvements**
  * Improved library browsing with responsive layouts, scrolling desktop tables, and mobile-friendly book cards.
  * Simplified rating choices to display numeric values instead of star symbols.
  * Improved delete button visibility, focus styling, and tap-target sizing.

* **Documentation**
  * Documented development server configuration and OAuth client selection behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

